### PR TITLE
Added: Set property type to OTHER for the boundary force code

### DIFF
--- a/SIMElasticity.h
+++ b/SIMElasticity.h
@@ -386,6 +386,7 @@ protected:
 
       else if (!strcasecmp(child->Value(),"isotropic"))
       {
+        IFEM::cout <<"  Parsing <"<< child->Value() <<">"<< std::endl;
         int code = this->parseMaterialSet(child,mVec.size());
         IFEM::cout <<"\tMaterial code "<< code <<":";
         if (Dim::dimension == 2)
@@ -395,6 +396,7 @@ protected:
       }
       else if (!strcasecmp(child->Value(),"bodyforce"))
       {
+        IFEM::cout <<"  Parsing <"<< child->Value() <<">"<< std::endl;
         std::string set, type;
         utl::getAttribute(child,"set",set);
         int code = this->getUniquePropertyCode(set,Dim::dimension==3?123:12);
@@ -411,6 +413,7 @@ protected:
       }
       else if (!strcasecmp(child->Value(),"boundaryforce"))
       {
+        IFEM::cout <<"  Parsing <"<< child->Value() <<">"<< std::endl;
         std::string set;
         if (utl::getAttribute(child,"set",set))
           bCode = this->getUniquePropertyCode(set);
@@ -420,6 +423,7 @@ protected:
         IFEM::cout <<"\tBoundary force ";
         if (!set.empty()) IFEM::cout <<"\""<< set <<"\" ";
         IFEM::cout <<"code "<< bCode << std::endl;
+        this->setPropertyType(bCode,Property::OTHER);
       }
 
       else if (!this->getIntegrand()->parse(child))


### PR DESCRIPTION
to avoid warning on undefined property during preprocessing. This removes the warning on undefined property sets during preprocessing.

Remember to pull the IFEM master before trying this one (the OTHER enum value, didn't bother a separate PR for that harmless one-liner). Could be a similar fix is needed for other apps (Stokes, etc,) using separate property codes for boundary force integration.