### PR TITLE
Changed: Dynamically allocate the BDFD2 member, and only when needed.

### DIFF
--- a/ElasticBase.C
+++ b/ElasticBase.C
@@ -12,8 +12,9 @@
 //==============================================================================
 
 #include "ElasticBase.h"
-#include "TimeDomain.h"
 #include "NewmarkMats.h"
+#include "TimeDomain.h"
+#include "BDF.h"
 
 
 ElasticBase::ElasticBase ()
@@ -24,6 +25,14 @@ ElasticBase::ElasticBase ()
   eS = iS = 0;
 
   memset(intPrm,0,sizeof(intPrm));
+
+  bdf = nullptr;
+}
+
+
+ElasticBase::~ElasticBase ()
+{
+  delete bdf;
 }
 
 
@@ -105,7 +114,10 @@ void ElasticBase::setMode (SIM::SolutionMode mode)
 
 void ElasticBase::setIntegrationPrm (unsigned short int i, double prm)
 {
-  if (i < sizeof(intPrm)/sizeof(double)) intPrm[i] = prm;
+  if (i < sizeof(intPrm)/sizeof(double))
+    intPrm[i] = prm;
+  else if (!bdf) // Using a Backward Difference Formula for time discretization
+    bdf = new TimeIntegration::BDFD2(2,prm);
 }
 
 
@@ -115,6 +127,12 @@ double ElasticBase::getIntegrationPrm (unsigned short int i) const
     return intPrm[i];
   else
     return 0.0;
+}
+
+
+void ElasticBase::advanceStep (double dt, double dtn)
+{
+  if (bdf) bdf->advanceStep(dt,dtn);
 }
 
 

--- a/ElasticBase.h
+++ b/ElasticBase.h
@@ -16,7 +16,8 @@
 
 #include "IntegrandBase.h"
 #include "Vec3.h"
-#include "BDF.h"
+
+namespace TimeIntegration { class BDFD2; }
 
 
 /*!
@@ -30,8 +31,8 @@ protected:
   ElasticBase();
 
 public:
-  //! \brief Empty destructor.
-  virtual ~ElasticBase() {}
+  //! \brief The destructor deletes the BDF object, if any.
+  virtual ~ElasticBase();
 
   //! \brief Defines the gravitation vector.
   void setGravity(const Vec3& g) { gravity = g; }
@@ -57,7 +58,7 @@ public:
   virtual double getIntegrationPrm(unsigned short int i) const;
 
   //! \brief Advances the BDF time step scheme one step forward.
-  void advanceStep(double dt, double dtn) { bdf.advanceStep(dt,dtn); }
+  void advanceStep(double dt, double dtn);
 
   //! \brief Returns whether this integrand has explicit boundary contributions.
   virtual bool hasBoundaryTerms() const { return false; }
@@ -95,8 +96,6 @@ protected:
   unsigned short int iS;  //!< Index to element internal force vector
   unsigned short int nSV; //!< Number of consequtive solution vectors in core
 
-  TimeIntegration::BDFD2 bdf; //!< BDF time discretization parameters
-
   //! \brief Newmark time integration parameters.
   //! \details The interpretation of each parameter
   //! depends on the actual simulator drivers, as follows: <UL>
@@ -114,6 +113,8 @@ protected:
   //! damping (if any), depending on material stiffness only.
   //! <LI> 4: 1.0 if HHTSIM is used, 2.0 if GenAlphaSIM is used, otherwise 0.0.
   double intPrm[5]; //!< </UL>
+
+  TimeIntegration::BDFD2* bdf; //!< BDF time discretization parameters
 };
 
 #endif

--- a/Elasticity.C
+++ b/Elasticity.C
@@ -129,8 +129,8 @@ LocalIntegral* Elasticity::getLocalIntegral (size_t nen, size_t,
   ElmMats* result;
   if (m_mode != SIM::DYNAMIC) // linear or nonlinear (quasi-)static analysis
     result = new ElmMats();
-  else if (!intPrm[0] && !intPrm[1] && !intPrm[2] && !intPrm[3])
-    result = new BDFMats(bdf);
+  else if (bdf)
+    result = new BDFMats(*bdf);
   else if (intPrm[3] > 0.0) // linear dynamic analysis
     result = new NewmarkMats(intPrm[0], intPrm[1], intPrm[2], intPrm[3],
                              intPrm[4] == 2.0);

--- a/SIMElasticity.C
+++ b/SIMElasticity.C
@@ -14,6 +14,9 @@
 #include "SIMElasticity.h"
 #include "SIM2D.h"
 
+//! Plane strain/stress option for 2D problems.
 template<> bool SIMElasticity<SIM2D>::planeStrain = false;
+//! Axisymmtry option for 2D problems.
 template<> bool SIMElasticity<SIM2D>::axiSymmetry = false;
+//! Option for output of Gauss points to VTF for 2D problems.
 template<> bool SIMElasticity<SIM2D>::GIpointsVTF = false;

--- a/SIMElasticity.h
+++ b/SIMElasticity.h
@@ -101,7 +101,7 @@ public:
   //!
   //! \details The boundary for which the traction is calculated is identified
   //! by the property set code \a bCode which is assigned value by parsing
-  //! the <boundaryforce> tag in the input file.
+  //! the `<boundaryforce>` tag in the input file.
   bool getBoundaryForce(Vector& f, const Vectors& sol, const TimeStep& tp)
   {
     if (bCode == 0) return false;
@@ -116,7 +116,7 @@ public:
   //!
   //! \details The boundary for which the reaction force is returned
   //! is identified by the property set code \a bCode which is assigned value
-  //! by parsing the <boundaryforce> tag in the input file.
+  //! by parsing the `<boundaryforce>` tag in the input file.
   bool getBoundaryReactions(Vector& rf)
   {
     if (bCode == 0) return false;


### PR DESCRIPTION
Then we are also able to set the initial value of its step member
from outside, using the setIntegrationPrm method.
