### PR TITLE
Fixed: Should be "\\" as continuation marker, right?

### DIFF
--- a/Linear/CMakeLists.txt
+++ b/Linear/CMakeLists.txt
@@ -35,9 +35,9 @@ target_link_libraries(LinEl Beam Elasticity ${IFEM_LIBRARIES})
 install(TARGETS LinEl DESTINATION bin COMPONENT bin)
 
 # For generating the doxy
-set(EXTRA_DOXY_PATHS "${PROJECT_SOURCE_DIR} \
-                      ${PROJECT_BINARY_DIR} \
-                      ${PROJECT_SOURCE_DIR}/.. \
+set(EXTRA_DOXY_PATHS "${PROJECT_SOURCE_DIR} \\
+                      ${PROJECT_BINARY_DIR} \\
+                      ${PROJECT_SOURCE_DIR}/.. \\
                       ${PROJECT_SOURCE_DIR}/../Beam")
 add_doc_target(LinEl LinEl)
 


### PR DESCRIPTION
In some apps, like FiniteDeformation and OpenFrac, it is used `\\` as continuation marker in the EXTRA_DOXY_PATH definition, whereas in others, like this one and BeamSIM, only a single `\` is used. Kjell Magne's student has problems with the latter when trying to build BeamSIM on Windows10, whereas it is no difference on Ubuntu, seemingly. So the question is, what is consistent to use for any platform?

Please verify this one and I will deal with the other apps later.