### PR TITLE
add some dummy symbols

### DIFF
--- a/SIMElasticity.C
+++ b/SIMElasticity.C
@@ -13,6 +13,7 @@
 
 #include "SIMElasticity.h"
 #include "SIM2D.h"
+#include "SIM3D.h"
 
 //! Plane strain/stress option for 2D problems.
 template<> bool SIMElasticity<SIM2D>::planeStrain = false;
@@ -20,3 +21,10 @@ template<> bool SIMElasticity<SIM2D>::planeStrain = false;
 template<> bool SIMElasticity<SIM2D>::axiSymmetry = false;
 //! Option for output of Gauss points to VTF for 2D problems.
 template<> bool SIMElasticity<SIM2D>::GIpointsVTF = false;
+
+//! Dummy plane strain/stress option for 3D problems.
+template<> bool SIMElasticity<SIM3D>::planeStrain = false;
+//! Dummy axisymmtry option for 3D problems.
+template<> bool SIMElasticity<SIM3D>::axiSymmetry = false;
+//! Dummy option for output of Gauss points to VTF for 3D problems.
+template<> bool SIMElasticity<SIM3D>::GIpointsVTF = false;


### PR DESCRIPTION
pgc doesn't seem to prune symbols as early in the process as gcc/clang does.

Downstream of https://github.com/OPM/IFEM/pull/151