### PR TITLE
Norm name fixes

### DIFF
--- a/Elasticity.C
+++ b/Elasticity.C
@@ -961,15 +961,15 @@ bool ElasticityNorm::evalInt (LocalIntegral& elmInt, const FiniteElement& fe,
   // Integrate the volume
   pnorm[ip++] += detJW;
 
-  size_t i, j, k;
-  for (i = 0; i < pnorm.psol.size(); i++)
-    if (!pnorm.psol[i].empty())
+  size_t j, k;
+  for (const Vector& psol : pnorm.psol)
+    if (!psol.empty())
     {
       // Evaluate projected stress field
       Vector sigmar(sigmah.size());
       for (j = k = 0; j < nrcmp && k < sigmar.size(); j++)
 	if (!planeStrain || j != 2)
-	  sigmar[k++] = pnorm.psol[i].dot(fe.N,j,nrcmp);
+	  sigmar[k++] = psol.dot(fe.N,j,nrcmp);
 
       // Integrate the energy norm a(u^r,u^r)
       pnorm[ip++] += sigmar.dot(Cinv*sigmar)*detJW;
@@ -1073,7 +1073,7 @@ std::string ElasticityNorm::getName (size_t i, size_t j,
   };
 
   const char** s = i > 1 ? p : u;
-  if (!anasol && j == 3) j = 5;
+  if (!anasol && i == 1 && j == 3) j = 5;
 
   if (!prefix)
     return s[j-1];

--- a/ElasticityUtils.h
+++ b/ElasticityUtils.h
@@ -26,6 +26,7 @@ namespace ElasticityUtils //! Dimension-independent utilities for Elasticity
   //! \param[in] gNorm The norm values to print
   //! \param[in] rNorm Reference norms for the first norm group
   //! \param[in] name Projection name associated with this norm group
+  //! \param[in] model The FE model associated with the norm values to print
   void printNorms(const Vector& gNorm, const Vector& rNorm,
                   const std::string& name, const SIMbase* model);
 }

--- a/Linear/Test/Biharmonic1D-p3.reg
+++ b/Linear/Test/Biharmonic1D-p3.reg
@@ -27,7 +27,7 @@ Parsing <boundaryconditions>
 Parsing <KirchhoffLove>
 	Material code 0: 1.2e+07 0 1 0.01
 	Pressure code 1 (expression): (120\*x-24)\*(y^2-1)^2 + 32\*(x-1)\*(5\*x^2+2\*x-1)\*(3\*y^2-1) + (x-1)\*(x^2-1)^2\*24
-Analytical solution: Expression
+	Analytical solution: Expression
 	Variables=wx=(x-1)\*(x^2-1)^2; dwx=(x^2-1)\*(5\*x^2-4\*x-1); ddwx=(x-1)\*(20\*x^2+8\*x-4); dddwx=60\*x^2-24\*x-12; ddddwx=120\*x-24; wy=(y^2-1)^2; dwy=4\*y\*(y^2-1); ddwy=12\*y^2-4; dddwy=24\*y; ddddwy=24;
 	Primary=wx\*wy
 	Secondary=ddwx\*wy|wx\*ddwy|dwx\*dwy

--- a/Linear/Test/Biharmonic1D-p3.xinp
+++ b/Linear/Test/Biharmonic1D-p3.xinp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
-<!-- Basic biharmonic equation test in 2D for p=2.
+<!-- Basic biharmonic equation test in 2D for p=3.
 Square clamped plate with varying load satisfying the manufactored solution:
 w(x,y) = wx(x)*wy(y) = (x-1)*(x^2-1)^2*(y^2-1)^2
 

--- a/Linear/Test/Harmonic1D-p3.reg
+++ b/Linear/Test/Harmonic1D-p3.reg
@@ -26,7 +26,7 @@ Parsing <boundaryconditions>
 Parsing <EulerBernoulli>
 	Material code 0: 1.2e+07 1 0.01
 	Pressure code 1 (expression): 120\*x+24
-Analytical solution: Expression
+	Analytical solution: Expression
 	Primary=(x-1)^3\*(x+2)^2
 	Secondary=(x-1)\*(20\*x^2+32\*x+2)
 	Derivative_11=120\*x+24
@@ -34,9 +34,6 @@ Parsing <postprocessing>
   Parsing <projection>
   Parsing <resultpoints>
 	Point 1: P1 xi = 0.5
-  Parsing <resultpoints>
-	Line 1: P1 npt = 100 xi = 0-1 0 0
-	Output file: Harmonic1D-p3.dat
 Parsing input file succeeded.
 Equation solver: 2
 Number of Gauss points: 3 5

--- a/Linear/Test/Harmonic1D-p3.xinp
+++ b/Linear/Test/Harmonic1D-p3.xinp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
-<!-- Basic harmonic equation test in 1D for p=2 !-->
+<!-- Basic harmonic equation test in 1D for p=3 !-->
 
 <simulation>
 
@@ -43,9 +43,11 @@
     <resultpoints>
       <point patch="1" u="0.5"/>
     </resultpoints>
+<!-- Activate this to plot the deflection along the entire line using a file
     <resultpoints file="Harmonic1D-p3.dat">
       <line u0="0.0" u1="1.0">100</line>
     </resultpoints>
+!-->
   </postprocessing>
 
 </simulation>

--- a/Linear/Test/LR/exact_p2.reg
+++ b/Linear/Test/LR/exact_p2.reg
@@ -1,11 +1,67 @@
-exact_p2.xinp -2D -LR
+exact_p2.xinp -2D -LR -cgl2
 
-Analytical solution: Expression
+Input file: exact_p2.xinp
+Equation solver: 2
+Number of Gauss points: 4
+LR-spline basis functions are used
+Enabled projection(s): Continuous global L2-projection
+Parsing input file exact_p2.xinp
+Parsing <discretization>
+Parsing <geometry>
+  Parsing <patchfile>
+	Reading data file simple_p2.lr
+	Reading patch 1
+  Parsing <topologysets>
+	Topology sets: edges (1,1,1D) (1,2,1D) (1,3,1D) (1,4,1D)
+	               model (1,0,2D)
+  Parsing <patchfile>
+  Parsing <topologysets>
+Parsing <boundaryconditions>
+  Parsing <dirichlet>
+	Dirichlet code 12: (analytic)
+Parsing <elasticity>
+  Parsing <isotropic>
+	Material code 0: 1000 0.3 0
+  Parsing <bodyforce>
+	Bodyforce code 1000012 (expression): 1000/(1-0.3^2)\*(-2\*y^2 - x^2 + 0.3\*x\*(x - 2\*y) - 2\*x\*y + 3 - 0.3) | 1000/(1-0.3^2)\*(-2\*x^2 - y^2 + 0.3\*y\*(y - 2\*x) - 2\*x\*y + 3 - 0.3)
+	Analytical solution: Expression
+	Variables=Emod=1000;v=0.3;
+	Primary=(1-x^2)\*(1-y^2)|(1-x^2)\*(1-y^2)
+	Stress=Emod/(1-v^2) \* 2\*( x\*(y^2-1) + v\*y\*(x^2-1)) | Emod/(1-v^2) \* 2\*(v\*x\*(y^2-1) + y\*(x^2-1)) | Emod/(1-v^2) \* (1-v)/2\*(2\*x\*(y^2-1) + 2\*y\*(x^2-1))
+Parsing input file succeeded.
+Equation solver: 2
+Number of Gauss points: 3 4
+LR-spline basis functions are used
+Enabled projection(s): Continuous global L2-projection
+Problem definition:
+Elasticity: 2D, gravity = 0 0
 LinIsotropic: plane stress, E = 1000, nu = 0.3, rho = 0, alpha = 1.2e-07
+Resolving Dirichlet boundary conditions
+	Constraining P1 E1 in direction(s) 12 code = 12
+	Constraining P1 E2 in direction(s) 12 code = 12
+	Constraining P1 E3 in direction(s) 12 code = 12
+	Constraining P1 E4 in direction(s) 12 code = 12
+ >>> SAM model summary <<<
 Number of elements    49
 Number of nodes       73
 Number of dofs        146
 Number of constraints 64
 Number of unknowns    82
-Energy norm \|u\^h\| = a(u\^h,u\^h)\^0.5   : 49.6692
-Exact norm  \|u\|   = a(u,u)\^0.5       : 49.6692
+Number of quadrature points 441
+Processing integrand associated with code 0
+Assembling interior matrix terms for P1
+Solving the equation system ...
+	Condition number: 103.777
+ >>> Solution summary <<<
+L2-norm            : 0.467743
+Max X-displacement : 1
+Max Y-displacement : 1
+Projecting secondary solution ...
+	Continuous global L2-projection
+Energy norm |u^h| = a(u^h,u^h)^0.5   : 49.6692
+External energy ((f,u^h)+(t,u^h)^0.5 : 36.8704
+Exact norm  |u|   = a(u,u)^0.5       : 49.6692
+>>> Error estimates based on Continuous global L2-projection <<<
+Energy norm |u^r| = a(u^r,u^r)^0.5   : 49.6692
+Energy norm |u^rr| = a(u^rr,u^rr)^0.5: 49.6692
+L2-norm |s^r| = (s^r,s^r)^0.5        : 1587.03

--- a/Linear/Test/LR/exact_p2.xinp
+++ b/Linear/Test/LR/exact_p2.xinp
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
-<--! Made-up exact polynomial solution (p=2) with mixed boundary conditions !-->
+<--! Made-up exact polynomial solution (p=2)
+     with non-homogenuous Dirichlet boundary conditions !-->
 
 <simulation>
 
   <!-- General - geometry definitions !-->
   <geometry>
-         <patchfile>simple_p2.lr</patchfile>
+    <patchfile>simple_p2.lr</patchfile>
     <topologysets>
       <set name="model" type="surface">
         <item>1</item>
@@ -22,19 +23,24 @@
     <dirichlet set="edges" type="anasol" comp="12"/>
   </boundaryconditions>
 
+  <discretization>
+    <nGauss>3 4</nGauss>
+  </discretization>
+
   <!-- Problem specific block !-->
   <elasticity>
     <isotropic E="1000" nu="0.3" rho="0"/>
     <bodyforce type="expression" set="model">
-      1000/(1-.3^2)*(-2*y^2 - x^2 + 0.3*x^2 - 2*.3*x*y - 2*x*y + 3 - .3)|
-      1000/(1-.3^2)*(-2*x^2 - y^2 + 0.3*y^2 - 2*.3*x*y - 2*x*y + 3 - .3)
+      1000/(1-0.3^2)*(-2*y^2 - x^2 + 0.3*x*(x - 2*y) - 2*x*y + 3 - 0.3) |
+      1000/(1-0.3^2)*(-2*x^2 - y^2 + 0.3*y*(y - 2*x) - 2*x*y + 3 - 0.3)
     </bodyforce>
     <anasol type="expression">
+      <variables>Emod=1000;v=0.3</variables>
       <primary>(1-x^2)*(1-y^2)|(1-x^2)*(1-y^2)</primary>
       <stress>
-        1000/(1-.3^2) *        2*(   x*(y^2-1) + .3*y*(x^2-1)) |
-        1000/(1-.3^2) * (1-.3)/2*( 2*x*(y^2-1) +  2*y*(x^2-1)) |
-        1000/(1-.3^2) *        2*(.3*x*(y^2-1) +    y*(x^2-1))
+        Emod/(1-v^2) *       2*(  x*(y^2-1) + v*y*(x^2-1)) |
+        Emod/(1-v^2) *       2*(v*x*(y^2-1) +   y*(x^2-1)) |
+        Emod/(1-v^2) * (1-v)/2*(2*x*(y^2-1) + 2*y*(x^2-1))
       </stress>
     </anasol>
   </elasticity>

--- a/Linear/Test/exact_p1.reg
+++ b/Linear/Test/exact_p1.reg
@@ -1,0 +1,97 @@
+exact_p1.xinp -2D -grvl -cgl2
+
+Input file: exact_p1.xinp
+Equation solver: 2
+Number of Gauss points: 4
+Enabled projection(s): Greville point projection
+                       Continuous global L2-projection
+Parsing input file exact_p1.xinp
+Parsing <discretization>
+Parsing <geometry>
+  Generating linear geometry on unit parameter domain \[0,1]^2
+  Parsing <refine>
+  Parsing <topologysets>
+	Topology sets: edges (1,1,1D) (1,2,1D) (1,3,1D) (1,4,1D)
+	               model (1,0,2D)
+  Parsing <refine>
+	Refining P1 7 7
+  Parsing <topologysets>
+Parsing <boundaryconditions>
+  Parsing <dirichlet>
+	Dirichlet code 12: (analytic)
+Parsing <elasticity>
+  Parsing <isotropic>
+	Material code 0: 1000 0.3 0
+  Parsing <bodyforce>
+	Bodyforce code 1000012 (expression): 1000/(1-0.3^2)\*(-2\*y^2 - x^2 + 0.3\*x\*(x - 2\*y) - 2\*x\*y + 3 - 0.3) | 1000/(1-0.3^2)\*(-2\*x^2 - y^2 + 0.3\*y\*(y - 2\*x) - 2\*x\*y + 3 - 0.3)
+	Analytical solution: Expression
+	Variables=Emod=1000;v=0.3;
+	Primary=(1-x^2)\*(1-y^2)|(1-x^2)\*(1-y^2)
+	Stress=Emod/(1-v^2) \* 2\*( x\*(y^2-1) + v\*y\*(x^2-1)) | Emod/(1-v^2) \* 2\*(v\*x\*(y^2-1) + y\*(x^2-1)) | Emod/(1-v^2) \* (1-v)/2\*(2\*x\*(y^2-1) + 2\*y\*(x^2-1))
+Parsing input file succeeded.
+Equation solver: 2
+Number of Gauss points: 2 3
+Enabled projection(s): Greville point projection
+                       Continuous global L2-projection
+Problem definition:
+Elasticity: 2D, gravity = 0 0
+LinIsotropic: plane stress, E = 1000, nu = 0.3, rho = 0, alpha = 1.2e-07
+Resolving Dirichlet boundary conditions
+	Constraining P1 E1 in direction(s) 12 code = 12
+	Constraining P1 E2 in direction(s) 12 code = 12
+	Constraining P1 E3 in direction(s) 12 code = 12
+	Constraining P1 E4 in direction(s) 12 code = 12
+ >>> SAM model summary <<<
+Number of elements    64
+Number of nodes       81
+Number of dofs        162
+Number of constraints 64
+Number of unknowns    98
+Number of quadrature points 256
+Processing integrand associated with code 0
+Assembling interior matrix terms for P1
+Solving the equation system ...
+	Condition number: 40.8568
+ >>> Solution summary <<<
+L2-norm            : 0.529895
+Max X-displacement : 1
+Max Y-displacement : 1
+Projecting secondary solution ...
+	Greville point projection
+Projecting secondary solution ...
+	Continuous global L2-projection
+Energy norm |u^h| = a(u^h,u^h)^0.5   : 49.4682
+External energy ((f,u^h)+(t,u^h)^0.5 : 38.5013
+Exact norm  |u|   = a(u,u)^0.5       : 49.6692
+Exact error a(e,e)^0.5, e=u-u^h      : 2.8788
+Exact relative error (%) : 5.79595
+>>> Error estimates based on Greville point projection <<<
+Energy norm |u^r| = a(u^r,u^r)^0.5   : 53.8529
+Error norm a(e,e)^0.5, e=u^r-u^h     : 6.1531
+ relative error (% of |u|)   : 12.3882
+Exact error a(e,e)^0.5, e=u-u^r      : 5.5381
+ relative error (% of |u|)   : 11.15
+Effectivity index             : 2.13738
+Energy norm |u^rr| = a(u^rr,u^rr)^0.5: 49.4935
+Error norm a(e,e)^0.5, e=u^rr-u^h    : 2.86419
+ relative error (% of |u|)   : 5.76652
+Exact error a(e,e)^0.5, e=u-u^rr     : 0.204652
+ relative error (% of |u|)   : 0.41203
+L2-norm |s^r| = (s^r,s^r)^0.5        : 1724.69
+L2-error (e,e)^0.5, e=s^r-s^h        : 198.689
+ relative error (% of |s^r|) : 11.5203
+>>> Error estimates based on Continuous global L2-projection <<<
+Energy norm |u^r| = a(u^r,u^r)^0.5   : 49.3908
+Error norm a(e,e)^0.5, e=u^r-u^h     : 2.76506
+ relative error (% of |u|)   : 5.56694
+Exact error a(e,e)^0.5, e=u-u^r      : 0.801228
+ relative error (% of |u|)   : 1.61313
+Effectivity index             : 0.960488
+Energy norm |u^rr| = a(u^rr,u^rr)^0.5: 49.6692
+Error norm a(e,e)^0.5, e=u^rr-u^h    : 2.87787
+ relative error (% of |u|)   : 5.79407
+Exact error a(e,e)^0.5, e=u-u^rr     : 0.0732511
+ relative error (% of |u|)   : 0.147478
+L2-norm |s^r| = (s^r,s^r)^0.5        : 1578.35
+L2-error (e,e)^0.5, e=s^r-s^h        : 86.8601
+ relative error (% of |s^r|) : 5.50323

--- a/Linear/Test/exact_p1.xinp
+++ b/Linear/Test/exact_p1.xinp
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
-<--! Made-up exact polynomial solution (p=2)
+<--! Made-up exact polynomial solution (p=1)
      with non-homogenuous Dirichlet boundary conditions !-->
 
 <simulation>
 
   <!-- General - geometry definitions !-->
   <geometry>
-    <raiseorder patch="1" u="1" v="1"/>
     <refine patch="1" u="7" v="7"/>
     <topologysets>
       <set name="model" type="surface">
@@ -25,7 +24,7 @@
   </boundaryconditions>
 
   <discretization>
-    <nGauss>3 4</nGauss>
+    <nGauss>2 3</nGauss>
   </discretization>
 
   <!-- Problem specific block !-->

--- a/Linear/Test/exact_p2.reg
+++ b/Linear/Test/exact_p2.reg
@@ -1,13 +1,66 @@
 exact_p2.xinp -2D
 
-Analytical solution: Expression
+Input file: exact_p2.xinp
+Equation solver: 2
+Number of Gauss points: 4
+Parsing input file exact_p2.xinp
+Parsing <discretization>
+Parsing <geometry>
+  Generating linear geometry on unit parameter domain \[0,1]^2
+  Parsing <raiseorder>
+  Parsing <refine>
+  Parsing <topologysets>
+	Topology sets: edges (1,1,1D) (1,2,1D) (1,3,1D) (1,4,1D)
+	               model (1,0,2D)
+  Parsing <raiseorder>
+	Raising order of P1 1 1
+  Parsing <refine>
+	Refining P1 7 7
+  Parsing <topologysets>
+Parsing <boundaryconditions>
+  Parsing <dirichlet>
+	Dirichlet code 12: (analytic)
+Parsing <elasticity>
+  Parsing <isotropic>
+	Material code 0: 1000 0.3 0
+  Parsing <bodyforce>
+	Bodyforce code 1000012 (expression): 1000/(1-0.3^2)\*(-2\*y^2 - x^2 + 0.3\*x\*(x - 2\*y) - 2\*x\*y + 3 - 0.3) | 1000/(1-0.3^2)\*(-2\*x^2 - y^2 + 0.3\*y\*(y - 2\*x) - 2\*x\*y + 3 - 0.3)
+	Analytical solution: Expression
+	Variables=Emod=1000;v=0.3;
+	Primary=(1-x^2)\*(1-y^2)|(1-x^2)\*(1-y^2)
+	Stress=Emod/(1-v^2) \* 2\*( x\*(y^2-1) + v\*y\*(x^2-1)) | Emod/(1-v^2) \* 2\*(v\*x\*(y^2-1) + y\*(x^2-1)) | Emod/(1-v^2) \* (1-v)/2\*(2\*x\*(y^2-1) + 2\*y\*(x^2-1))
+Parsing input file succeeded.
+Equation solver: 2
+Number of Gauss points: 3 4
+Problem definition:
+Elasticity: 2D, gravity = 0 0
 LinIsotropic: plane stress, E = 1000, nu = 0.3, rho = 0, alpha = 1.2e-07
+Resolving Dirichlet boundary conditions
+	Constraining P1 E1 in direction(s) 12 code = 12
+	Constraining P1 E2 in direction(s) 12 code = 12
+	Constraining P1 E3 in direction(s) 12 code = 12
+	Constraining P1 E4 in direction(s) 12 code = 12
+ >>> SAM model summary <<<
 Number of elements    64
 Number of nodes       100
 Number of dofs        200
 Number of constraints 72
 Number of unknowns    128
-Number of quadrature points 1024
+Number of quadrature points 576
+Processing integrand associated with code 0
+Assembling interior matrix terms for P1
+Solving the equation system ...
+	Condition number: 26.9958
+ >>> Solution summary <<<
+L2-norm            : 0.530859
+Max X-displacement : 1
+Max Y-displacement : 1
+Projecting secondary solution ...
+	Greville point projection
 Energy norm |u^h| = a(u^h,u^h)^0.5   : 49.6692
 External energy ((f,u^h)+(t,u^h)^0.5 : 41.5203
 Exact norm  |u|   = a(u,u)^0.5       : 49.6692
+>>> Error estimates based on Greville point projection <<<
+Energy norm |u^r| = a(u^r,u^r)^0.5   : 49.6692
+Energy norm |u^rr| = a(u^rr,u^rr)^0.5: 49.6692
+L2-norm |s^r| = (s^r,s^r)^0.5        : 1587.03

--- a/Linear/main_LinEl.C
+++ b/Linear/main_LinEl.C
@@ -381,7 +381,7 @@ int main (int argc, char** argv)
           IFEM::cout <<"\nExact norm  |u|   = a(u,u)^0.5       : "<< norm(3)
                      <<"\nExact error a(e,e)^0.5, e=u-u^h      : "<< norm(4)
                      <<"\nExact relative error (%) : "<< norm(4)*Rel;
-        if (model->haveAnaSol() && norm.size() >= 5)
+        if (model->haveAnaSol() && norm.size() >= 6)
           IFEM::cout <<"\nResidual error (r(u) + J(u))^0.5 : "<< norm(5)
                      <<"\n- relative error (% of |u|) : "<< norm(5)*Rel;
       }


### PR DESCRIPTION
This essentially fixes two small things:
* Wrong name on the third norm when no analytical solution (was a(e,e)^0.5,e=u-u^r should be (u^r,u^r)
* Avoid printing non-existing residual error in the norm summary for Elasticity (so far exisiting for KL only). Done by inserting integration of area for KirchhoffLove, equivalent to volume for Elasticity.
Also added a linear regression test with non-zero errors.