### PR TITLE
changed: redirect doxygen warnings to a log file

### DIFF
--- a/Linear/doc/Doxyfile.in
+++ b/Linear/doc/Doxyfile.in
@@ -553,7 +553,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # and error messages should be written. If left blank the output is written 
 # to stderr.
 
-WARN_LOGFILE           = 
+WARN_LOGFILE           = @PROJECT_BINARY_DIR@/DoxyWarnings.log
 
 #---------------------------------------------------------------------------
 # configuration options related to the input files


### PR DESCRIPTION
easier to inspect than terminal output, and aids jenkins

https://github.com/OPM/IFEM/pull/252
