### PR TITLE
changed: reorganize some pointer juggeling to appease the static analyzer gods

### DIFF
--- a/NewmarkDriver.h
+++ b/NewmarkDriver.h
@@ -87,7 +87,7 @@ public:
     double nextSave = params.time.t + Newmark::opt.dtSave;
 
     std::streamsize ptPrec = outPrec > 0 ? outPrec : 3;
-    std::ostream* os = &std::cout;
+    std::ostream* os = nullptr;
     if (!pointfile.empty())
       os = new std::ofstream(pointfile.c_str());
 
@@ -112,7 +112,7 @@ public:
       }
 
       // Print solution components at the user-defined points
-      utl::LogStream log(*os);
+      utl::LogStream log(os ? os : &std::cout);
       this->dumpResults(params.time.t,log,ptPrec,pointfile.empty());
 
       if (params.hasReached(nextSave))
@@ -141,8 +141,7 @@ public:
       }
     }
 
-    if (!pointfile.empty())
-      delete os;
+    delete os;
 
     return status;
   }


### PR DESCRIPTION
clang-check is too stopid to read the original code properly, http://afem:8080/view/Static%20analyses/job/IFEM-FiniteDeformation-static-analysis/lastCompletedBuild/testReport/(root)/serial/clang_check_main_C/

this is purely a reorganization to help the feeble minded.