### PR TITLE
changed: add explicit instance declarations to make clang happy

### DIFF
--- a/Linear/SIMLinEl.h
+++ b/Linear/SIMLinEl.h
@@ -74,4 +74,9 @@ template<> bool SIMLinEl3D::parseDimSpecific(char* keyWord, std::istream& is);
 //! \brief Template specialization - 3D specific input parsing.
 template<> bool SIMLinEl3D::parseDimSpecific(const TiXmlElement* elem);
 
+//! \brief Explicit instance declaration.
+template<> bool SIMLinEl2D::GIpointsVTF;
+//! \brief Explicit instance declaration.
+template<> bool SIMLinEl3D::GIpointsVTF;
+
 #endif

--- a/Linear/main_LinEl.C
+++ b/Linear/main_LinEl.C
@@ -12,6 +12,7 @@
 //==============================================================================
 
 #include "IFEM.h"
+#include "SIMElasticityInstance.h"
 #include "SIMLinEl.h"
 #include "SIMLinElKL.h"
 #include "SIMLinElBeamC1.h"

--- a/SIMElasticityInstance.h
+++ b/SIMElasticityInstance.h
@@ -1,0 +1,26 @@
+// $Id$
+//==============================================================================
+//!
+//! \file SIMElasticity.h
+//!
+//! \date Dec 08 2009
+//!
+//! \author Knut Morten Okstad / SINTEF
+//!
+//! \brief Solution driver for NURBS-based linear elastic FEM analysis.
+//!
+//==============================================================================
+
+#ifndef _SIM_ELASTICITY_INSTANCE_H
+#define _SIM_ELASTICITY_INSTANCE_H
+
+#include "SIMElasticity.h"
+#include "SIM2D.h"
+#include "SIM3D.h"
+
+template<> bool SIMElasticity<SIM2D>::planeStrain;
+template<> bool SIMElasticity<SIM3D>::planeStrain;
+template<> bool SIMElasticity<SIM2D>::axiSymmetry;
+template<> bool SIMElasticity<SIM3D>::axiSymmetry;
+
+#endif

--- a/SIMElasticityWrap.h
+++ b/SIMElasticityWrap.h
@@ -14,7 +14,7 @@
 #ifndef _SIM_ELASTICITY_WRAP_H_
 #define _SIM_ELASTICITY_WRAP_H_
 
-#include "SIMElasticity.h"
+#include "SIMElasticityInstance.h"
 #include "DataExporter.h"
 
 


### PR DESCRIPTION
right now there is a separate file for SIMElasticity since I did not
want to introduce SIM2D/SIM3D in that file. perhaps the better alternative
is to do like for SIMLinEl there as well.