### PR TITLE
Changed: Moved some public static variables in SIMElasticity scope

### DIFF
--- a/Beam/ElasticBeam.C
+++ b/Beam/ElasticBeam.C
@@ -7,7 +7,7 @@
 //!
 //! \author Knut Morten Okstad / SINTEF
 //!
-//! \brief Class representing a non-linear elastic beam.
+//! \brief Class representing a nonlinear elastic beam.
 //!
 //==============================================================================
 
@@ -67,7 +67,7 @@ typedef BeamMats<NewmarkMats> NewmarkBeamMats;
 template<> NewmarkBeamMats::BeamMats (double a1, double a2, double b, double c)
   : NewmarkMats(a1,a2,b,c) {}
 
-//! Element matrices and data for non-linear dynamic beam FE problems
+//! Element matrices and data for nonlinear dynamic beam FE problems
 typedef BeamMats<HHTMats> HHTBeamMats;
 
 template<> HHTBeamMats::BeamMats (double a1, double a2, double b, double)
@@ -592,7 +592,7 @@ bool ElasticBeam::evalInt (LocalIntegral& elmInt,
 {
   // Calculate initial element length
   Vec3 X0 = fe.XC[1] - fe.XC[0];
-  double L, L0 = X0.length();
+  double L0 = X0.length();
   if (L0 <= 1.0e-8)
   {
     std::cerr <<" *** ElasticBeam::evalInt: Zero initial element length "
@@ -604,15 +604,13 @@ bool ElasticBeam::evalInt (LocalIntegral& elmInt,
 #endif
 
   const Vector& eV = elmInt.vec.front();
-  if (eV.empty())
-    L = L0;
-  else
+  if (!eV.empty())
   {
     // Calculate current element length
     Vec3 U1(eV.ptr(),npv);
     Vec3 U2(eV.ptr()+eV.size()-npv,npv);
     Vec3 X1 = X0 + U2 - U1;
-    L = X1.length();
+    double L = X1.length();
     if (L <= 1.0e-8)
     {
       std::cerr <<" *** ElasticBeam::evalInt: Zero element length "

--- a/ElasticityUtils.h
+++ b/ElasticityUtils.h
@@ -20,7 +20,7 @@
 class SIMbase;
 
 
-namespace ElasticityUtils //! Dimension-independent utilities for Elasticity
+namespace Elastic //! Dimension-independent utilities for Elasticity
 {
   //! \brief Prints a norm group to the log stream.
   //! \param[in] gNorm The norm values to print
@@ -29,6 +29,10 @@ namespace ElasticityUtils //! Dimension-independent utilities for Elasticity
   //! \param[in] model The FE model associated with the norm values to print
   void printNorms(const Vector& gNorm, const Vector& rNorm,
                   const std::string& name, const SIMbase* model);
+
+  extern bool planeStrain; //!< Plane strain/stress option - 2D only
+  extern bool axiSymmetry; //!< Axisymmtry option - 2D only
+  extern bool GIpointsVTF; //!< Option for Gauss point output to VTF
 }
 
 #endif

--- a/Linear/SIMLinEl.h
+++ b/Linear/SIMLinEl.h
@@ -39,8 +39,8 @@ protected:
   {
     if (!Dim::myProblem)
       Dim::myProblem = new LinearElasticity(Dim::dimension,
-                                            SIMElasticity<Dim>::axiSymmetry,
-                                            GIpointsVTF);
+                                            Elastic::axiSymmetry,
+                                            Elastic::GIpointsVTF);
 
     return dynamic_cast<Elasticity*>(Dim::myProblem);
   }
@@ -56,9 +56,6 @@ protected:
   //! while still reusing as much code as possible.
   //! Only put dimension-specific code in here.
   virtual bool parseDimSpecific(const TiXmlElement* elem);
-
-public:
-  static bool GIpointsVTF; //!< Gauss point output to VTF option
 };
 
 typedef SIMLinEl<SIM2D> SIMLinEl2D; //!< 2D specific driver

--- a/Linear/SIMLinEl2D.C
+++ b/Linear/SIMLinEl2D.C
@@ -14,9 +14,6 @@
 #include "SIMLinEl.h"
 #include "AnalyticSolutions.h"
 
-//! Option for output of Gauss points to VTF for 2D problems.
-template<> bool SIMLinEl2D::GIpointsVTF = false;
-
 
 template<> bool SIMLinEl2D::parseDimSpecific (char* keyWord, std::istream& is)
 {

--- a/Linear/SIMLinEl3D.C
+++ b/Linear/SIMLinEl3D.C
@@ -15,9 +15,6 @@
 #include "AnalyticSolutions.h"
 #include "Vec3Oper.h"
 
-//! Option for output of Gauss points to VTF for 3D problems.
-template<> bool SIMLinEl3D::GIpointsVTF = false;
-
 
 template<> bool SIMLinEl3D::parseDimSpecific (char* keyWord, std::istream& is)
 {

--- a/Linear/SIMLinElBeamC1.C
+++ b/Linear/SIMLinElBeamC1.C
@@ -40,7 +40,7 @@ bool SIMLinElBeamC1::parse (char* keyWord, std::istream& is)
   if (!myProblem)
     myProblem = new KirchhoffLovePlate(1);
 
-  char* cline = 0;
+  char* cline;
   KirchhoffLovePlate* klp = dynamic_cast<KirchhoffLovePlate*>(myProblem);
   if (!klp) return false;
 
@@ -247,7 +247,7 @@ bool SIMLinElBeamC1::initBodyLoad (size_t patchInd)
     if (prop.pcode == Property::BODYLOAD && prop.patch == patchInd)
       if ((it = myScalars.find(prop.pindx)) != myScalars.end()) break;
 
-  klp->setPressure(it == myScalars.end() ? 0 : it->second);
+  klp->setPressure(it == myScalars.end() ? nullptr : it->second);
   return true;
 }
 
@@ -317,5 +317,5 @@ double SIMLinElBeamC1::externalEnergy (const Vectors& u,
 void SIMLinElBeamC1::printNormGroup (const Vector& gNorm, const Vector& rNorm,
                                      const std::string& prjName) const
 {
-  ElasticityUtils::printNorms(gNorm,rNorm,prjName,this);
+  Elastic::printNorms(gNorm,rNorm,prjName,this);
 }

--- a/Linear/main_LinEl.C
+++ b/Linear/main_LinEl.C
@@ -136,7 +136,7 @@ int main (int argc, char** argv)
     else if (!strcmp(argv[i],"-voz") && i < argc-1)
       VTF::vecOffset[2] = atof(argv[++i]);
     else if (!strcmp(argv[i],"-plotSC"))
-      SIMLinEl2D::GIpointsVTF = Immersed::plotCells = true;
+      Elastic::GIpointsVTF = Immersed::plotCells = true;
     else if (!strcmp(argv[i],"-free"))
       SIMbase::ignoreDirichlet = true;
     else if (!strcmp(argv[i],"-check"))
@@ -160,12 +160,12 @@ int main (int argc, char** argv)
     else if (!strncmp(argv[i],"-2Dpstra",8))
     {
       args.dim = 2;
-      SIMLinEl2D::planeStrain = true;
+      Elastic::planeStrain = true;
     }
     else if (!strncmp(argv[i],"-2Daxi",6))
     {
       args.dim = 2;
-      SIMLinEl2D::axiSymmetry = true;
+      Elastic::axiSymmetry = true;
     }
     else if (!strncmp(argv[i],"-noP",4))
       noProj = true;

--- a/SIMElasticity.C
+++ b/SIMElasticity.C
@@ -11,23 +11,21 @@
 //!
 //==============================================================================
 
-#include "SIMElasticity.h"
-#include "SIM2D.h"
-#include "SIM3D.h"
+#include "ElasticityUtils.h"
+#include "SIMbase.h"
+#include "IFEM.h"
+
 
 //! Plane strain/stress option for 2D problems.
-template<> bool SIMElasticity<SIM2D>::planeStrain = false;
+bool Elastic::planeStrain = false;
 //! Axisymmtry option for 2D problems.
-template<> bool SIMElasticity<SIM2D>::axiSymmetry = false;
-
-//! Dummy option for 3D problems.
-template<> bool SIMElasticity<SIM3D>::planeStrain = false;
-//! Dummy option for 3D problems.
-template<> bool SIMElasticity<SIM3D>::axiSymmetry = false;
+bool Elastic::axiSymmetry = false;
+//! Option for Gauss point output to VTF
+bool Elastic::GIpointsVTF = false;
 
 
-void ElasticityUtils::printNorms (const Vector& gNorm, const Vector& rNorm,
-                                  const std::string& name, const SIMbase* model)
+void Elastic::printNorms (const Vector& gNorm, const Vector& rNorm,
+                          const std::string& name, const SIMbase* model)
 {
   const char* uRef = model->haveAnaSol() ? "|u|)   : " : "|u^r|) : ";
   double Rel = 100.0/(model->haveAnaSol() ? rNorm(3) : gNorm(1));

--- a/SIMElasticity.h
+++ b/SIMElasticity.h
@@ -195,11 +195,6 @@ protected:
     return true;
   }
 
-public:
-  static bool planeStrain; //!< Plane strain/stress option - 2D only
-  static bool axiSymmetry; //!< Axisymmtry option - 2D only
-
-protected:
   //! \brief Returns the actual integrand.
   virtual Elasticity* getIntegrand() = 0;
   //! \brief Parses a dimension-specific data section from an input file.
@@ -231,10 +226,8 @@ protected:
         IFEM::cout <<"\tMaterial code "<< code <<": ";
         if (code > 0)
           this->setPropertyType(code,Property::MATERIAL,mVec.size());
-        if (Dim::dimension == 2)
-          mVec.push_back(elInt->parseMatProp((char*)nullptr,planeStrain));
-        else
-          mVec.push_back(elInt->parseMatProp((char*)nullptr));
+        bool planeStrain = Dim::dimension == 2 ? Elastic::planeStrain : true;
+        mVec.push_back(elInt->parseMatProp((char*)nullptr,planeStrain));
         IFEM::cout << std::endl;
       }
     }
@@ -325,10 +318,8 @@ protected:
       for (int i = 0; i < nmat && (cline = utl::readLine(is)); i++)
       {
         IFEM::cout <<"\tMaterial data: ";
-        if (Dim::dimension == 2)
-          mVec.push_back(elInt->parseMatProp(cline,planeStrain));
-        else
-          mVec.push_back(elInt->parseMatProp(cline));
+        bool planeStrain = Dim::dimension == 2 ? Elastic::planeStrain : true;
+        mVec.push_back(elInt->parseMatProp(cline,planeStrain));
 
         while ((cline = strtok(nullptr," ")))
           if (!strncasecmp(cline,"ALL",3))
@@ -402,10 +393,8 @@ protected:
         IFEM::cout <<"  Parsing <"<< child->Value() <<">"<< std::endl;
         int code = this->parseMaterialSet(child,mVec.size());
         IFEM::cout <<"\tMaterial code "<< code <<":";
-        if (Dim::dimension == 2)
-          mVec.push_back(this->getIntegrand()->parseMatProp(child,planeStrain));
-        else
-          mVec.push_back(this->getIntegrand()->parseMatProp(child));
+        bool planeStrain = Dim::dimension == 2 ? Elastic::planeStrain : true;
+        mVec.push_back(this->getIntegrand()->parseMatProp(child,planeStrain));
       }
       else if (!strcasecmp(child->Value(),"bodyforce"))
       {
@@ -497,7 +486,7 @@ public:
   virtual void printNormGroup (const Vector& gNorm, const Vector& rNorm,
                                const std::string& prjName) const
   {
-    ElasticityUtils::printNorms(gNorm,rNorm,prjName,this);
+    Elastic::printNorms(gNorm,rNorm,prjName,this);
   }
 
 protected:


### PR DESCRIPTION
They are now places in the namespace Elastic instead, mostly because SIMElasticy is a template class such that we (according to Clang) needed one instance of these variables for each template instantiation even though they were relevant for 2D only.

This is an alternative to #54. It has a somewhat larger footprint but we get rid of the dummy 3D variables.
Yet another alternative could be to place them directly in Elasticity scope.