### PR TITLE
Line load for Kirchhoff-Love plate problems

### DIFF
--- a/KirchhoffLove.h
+++ b/KirchhoffLove.h
@@ -60,6 +60,8 @@ public:
   void setMaterial(Material* mat) { material = mat; }
   //! \brief Defines the pressure field.
   void setPressure(RealFunc* pf = nullptr);
+  //! \brief Defines the line load function.
+  void setLineLoad(RealFunc* lf) { linLoad = lf; }
   //! \brief Defines the traction field to use in Neumann boundary conditions.
   void setTraction(TractionFunc* tf) { tracFld = tf; fluxFld = nullptr; }
   //! \brief Defines the traction field to use in Neumann boundary conditions.
@@ -91,6 +93,8 @@ public:
   Vec3 getTraction(const Vec3& X, const Vec3& n) const;
   //! \brief Evaluates the pressure field (if any) at specified point.
   Vec3 getPressure(const Vec3& X, const Vec3& n = Vec3(0.0,0.0,1.0)) const;
+  //! \brief Evaluates the line load field (if any) at specified point.
+  Vec3 getLineLoad(const Vec3& X, const Vec3& n = Vec3(0.0,0.0,1.0)) const;
   //! \brief Returns whether external loads are defined.
   bool haveLoads(char type = 'A') const;
 
@@ -167,6 +171,7 @@ protected:
 
   VecFunc*      fluxFld; //!< Pointer to explicit boundary traction field
   TractionFunc* tracFld; //!< Pointer to implicit boundary traction field
+  RealFunc*     linLoad; //!< Pointer to line load function
   LocalSystem*  locSys;  //!< Local coordinate system for result output
 
   std::vector<RealFunc*> presFld; //!< Pointers to pressure field functions

--- a/Linear/KirchhoffLovePlate.h
+++ b/Linear/KirchhoffLovePlate.h
@@ -57,6 +57,13 @@ public:
   //! \param[in] X Cartesian coordinates of current integration point
   virtual bool evalInt(LocalIntegral& elmInt, const FiniteElement& fe,
                        const Vec3& X) const;
+  //! \brief Evaluates the integrand at an element interface point.
+  //! \param elmInt The local integral object to receive the contributions
+  //! \param[in] fe Finite element data of current integration point
+  //! \param[in] X Cartesian coordinates of current integration point
+  //! \param[in] normal Interface normal vector at current integration point
+  virtual bool evalInt(LocalIntegral& elmInt, const FiniteElement& fe,
+                       const Vec3& X, const Vec3& normal) const;
 
   using KirchhoffLove::evalBou;
   //! \brief Evaluates the integrand at a boundary point.
@@ -159,6 +166,13 @@ public:
   //! \param[in] X Cartesian coordinates of current integration point
   virtual bool evalInt(LocalIntegral& elmInt, const FiniteElement& fe,
                        const Vec3& X) const;
+  //! \brief Evaluates the integrand at an element interface point.
+  //! \param elmInt The local integral object to receive the contributions
+  //! \param[in] fe Finite element data of current integration point
+  //! \param[in] X Cartesian coordinates of current integration point
+  //! \param[in] normal Interface normal vector at current integration point
+  virtual bool evalInt(LocalIntegral& elmInt, const FiniteElement& fe,
+                       const Vec3& X, const Vec3& normal) const;
 
   using NormBase::evalBou;
   //! \brief Evaluates the integrand at a boundary point.

--- a/Linear/Test/Cantilever-KLplate.reg
+++ b/Linear/Test/Cantilever-KLplate.reg
@@ -4,6 +4,7 @@ Input file: Cantilever-KLplate.xinp
 Equation solver: 2
 Number of Gauss points: 4
 Spline basis with C1-continuous patch interfaces is used
+Solution component output zero tolerance: 1e-06
 Parsing input file Cantilever-KLplate.xinp
 Parsing <discretization>
 Parsing <geometry>
@@ -14,6 +15,7 @@ Parsing <geometry>
   Parsing <refine>
   Parsing <topologysets>
 	Topology sets: boundary (1,1,1D)
+	               tip (1,2,1D)
   Parsing <raiseorder>
 	Raising order of P1 2 0
   Parsing <refine>
@@ -22,10 +24,10 @@ Parsing <geometry>
 Parsing <boundaryconditions>
   Parsing <dirichlet>
 	Dirichlet code 1001: (fixed)
+  Parsing <neumann>
+	Neumann code 1000000 direction 1 (constant): 0 0 -1
 Parsing <KirchhoffLove>
 	Material code 0: 1e+06 0 1000 0.1
-	Point: P1 xi = 1 0 load = -0.5
-	Point: P1 xi = 1 1 load = -0.5
 Parsing <postprocessing>
   Parsing <resultpoints>
 	Point 1: P1 xi = 1 0
@@ -46,12 +48,13 @@ Number of elements    10
 Number of nodes       26
 Number of dofs        26
 Number of unknowns    22
-Load point #1: patch #1 (u,v)=(1,0), node #13, X = 10 0 0
-Load point #2: patch #1 (u,v)=(1,1), node #26, X = 10 1 0
-Number of quadrature points 30
+Number of quadrature points 30 2
 Processing integrand associated with code 0
 Assembling interior matrix terms for P1
+Assembling Neumann matrix terms for boundary 2 on P1
+  \* Sum external load: -1
 Solving the equation system ...
+	Condition number: 85635
  >>> Solution summary <<<
 L2-norm            : 2.15544
 Max displacement   : 4

--- a/Linear/Test/Cantilever-KLplate.xinp
+++ b/Linear/Test/Cantilever-KLplate.xinp
@@ -13,6 +13,9 @@
       <set name="boundary" type="edge">
         <item patch="1">1</item>
       </set>
+      <set name="tip" type="edge">
+        <item patch="1">2</item>
+      </set>
     </topologysets>
   </geometry>
 
@@ -24,13 +27,12 @@
   <!-- General - boundary conditions !-->
   <boundaryconditions>
     <dirichlet set="boundary" comp="1001"/>
+    <neumann set="tip" direction="1" type="constant">0.0 0.0 -1.0</neumann>
   </boundaryconditions>
 
   <!-- Problem specific block !-->
   <KirchhoffLove>
     <isotropic E="1.0e6" nu="0.0" rho="1.0e3" thickness="0.1"/>
-    <pointload patch="1" xi="1.0" eta="0.0">-0.5</pointload>
-    <pointload patch="1" xi="1.0" eta="1.0">-0.5</pointload>
   </KirchhoffLove>
 
   <!-- General - point result output !-->

--- a/Linear/Test/Cantilever-KLshell.reg
+++ b/Linear/Test/Cantilever-KLshell.reg
@@ -4,6 +4,7 @@ Input file: Cantilever-KLshell.xinp
 Equation solver: 2
 Number of Gauss points: 4
 Spline basis with C1-continuous patch interfaces is used
+Solution component output zero tolerance: 1e-06
 Parsing input file Cantilever-KLshell.xinp
 Parsing <discretization>
 Parsing <geometry>
@@ -14,6 +15,7 @@ Parsing <geometry>
   Parsing <refine>
   Parsing <topologysets>
 	Topology sets: boundary (1,1,1D)
+	               tip (1,2,1D)
   Parsing <raiseorder>
 	Raising order of P1 2 0
   Parsing <refine>
@@ -22,10 +24,10 @@ Parsing <geometry>
 Parsing <boundaryconditions>
   Parsing <dirichlet>
 	Dirichlet code 3123: (fixed)
+  Parsing <neumann>
+	Neumann code 1000000 direction 3 (constant): -1
 Parsing <KirchhoffLove>
 	Material code 0: 1e+06 0 1000 0.1
-	Point: P1 xi = 1 0 direction = 3 load = -0.5
-	Point: P1 xi = 1 1 direction = 3 load = -0.5
 Parsing <postprocessing>
   Parsing <resultpoints>
 	Point 1: P1 xi = 1 0
@@ -46,12 +48,15 @@ Number of elements    10
 Number of nodes       26
 Number of dofs        78
 Number of unknowns    70
-Load point #1: patch #1 (u,v)=(1,0), node #13, X = 10 0 0, direction = 3
-Load point #2: patch #1 (u,v)=(1,1), node #26, X = 10 1 0, direction = 3
-Number of quadrature points 80
+Number of quadrature points 80 2
 Processing integrand associated with code 0
 Assembling interior matrix terms for P1
+Assembling Neumann matrix terms for boundary 2 on P1
+  \* Sum external load: 0 0 -1
 Solving the equation system ...
+	Condition number: 170854
  >>> Solution summary <<<
 L2-norm            : 1.24444
 Max Z-displacement : 4
+  Node #13:	sol1 =  0.000000e+00  0.000000e+00 -4.000000e+00
+  Node #26:	sol1 =  0.000000e+00  0.000000e+00 -4.000000e+00

--- a/Linear/Test/Cantilever-KLshell.xinp
+++ b/Linear/Test/Cantilever-KLshell.xinp
@@ -13,6 +13,9 @@
       <set name="boundary" type="edge">
         <item patch="1">1</item>
       </set>
+      <set name="tip" type="edge">
+        <item patch="1">2</item>
+      </set>
     </topologysets>
   </geometry>
 
@@ -24,13 +27,12 @@
   <!-- General - boundary conditions !-->
   <boundaryconditions>
     <dirichlet set="boundary" comp="3123"/>
+    <neumann set="tip" direction="3" type="constant">-1.0</neumann>
   </boundaryconditions>
 
   <!-- Problem specific block !-->
   <KirchhoffLove>
     <isotropic E="1.0e6" nu="0.0" rho="1.0e3" thickness="0.1"/>
-    <pointload patch="1" xi="1.0" eta="0.0" direction="3">-0.5</pointload>
-    <pointload patch="1" xi="1.0" eta="1.0" direction="3">-0.5</pointload>
   </KirchhoffLove>
 
   <!-- General - point result output !-->

--- a/Linear/Test/PlateLineLoad.reg
+++ b/Linear/Test/PlateLineLoad.reg
@@ -1,0 +1,63 @@
+PlateLineLoad.xinp -2DKL
+
+Input file: PlateLineLoad.xinp
+Equation solver: 2
+Number of Gauss points: 4
+Spline basis with C1-continuous patch interfaces is used
+Solution component output zero tolerance: 1e-06
+Parsing input file PlateLineLoad.xinp
+Parsing <discretization>
+Parsing <geometry>
+  Generating linear geometry on unit parameter domain \[0,1]^2
+  Parsing <raiseorder>
+  Parsing <refine>
+  Parsing <raiseorder>
+	Raising order of P1 1 1
+  Parsing <refine>
+	Refining P1 19 19
+Parsing <geometry>
+  Parsing <topologysets>
+	Topology sets: boundary (1,1,1D) (1,2,1D) (1,3,1D) (1,4,1D)
+	               plate (1,0,2D)
+  Parsing <topologysets>
+Parsing <boundaryconditions>
+  Parsing <dirichlet>
+	Dirichlet code 1: (fixed)
+Parsing <kirchhofflove>
+	Material code 0: 1 0.3 1 1
+	Line load code 1000001 (constant): 2
+	at u=0.5, v in \[0.25,0.75]
+Parsing <postprocessing>
+  Parsing <resultpoints>
+	Point 1: P1 xi = 0.5 0.5
+Parsing input file succeeded.
+Equation solver: 2
+Number of Gauss points: 3 5
+Spline basis with C1-continuous patch interfaces is used
+Problem definition:
+KirchhoffLovePlate: thickness = 1, gravity = 0
+LinIsotropic: plane stress, E = 1, nu = 0.3, rho = 1, alpha = 0
+Resolving Dirichlet boundary conditions
+	Constraining P1 E1 in direction(s) 1
+	Constraining P1 E2 in direction(s) 1
+	Constraining P1 E3 in direction(s) 1
+	Constraining P1 E4 in direction(s) 1
+Result point #1: patch #1 (u,v)=(0.5,0.5), X = 0.5 0.5 0
+ >>> SAM model summary <<<
+Number of elements    400
+Number of nodes       484
+Number of dofs        484
+Number of unknowns    400
+Number of quadrature points 3600
+Processing integrand associated with code 0
+Assembling interior matrix terms for P1
+Solving the equation system ...
+	Condition number: 16113.4
+ >>> Solution summary <<<
+L2-norm            : 0.0461567
+Max displacement   : 0.107229
+Integrating solution norms (FE solution) ...
+Energy norm |u^h| = a(u^h,u^h)^0.5   : 0.309343
+External energy ((f,u^h)+(t,u^h)^0.5 : 0.309343
+  Point #1:	sol1 =  1.072286e-01
+		sol2 =  1.849172e-01  1.505577e-01  0.000000e+00

--- a/Linear/Test/PlateLineLoad.xinp
+++ b/Linear/Test/PlateLineLoad.xinp
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<--! Simply supported square plate with a line load in the middle.
+     Quadratic spline Kirchhoff-Love thin plate elements. -->
+
+<simulation>
+
+  <geometry>
+    <raiseorder patch="1" u="1" v="1"/>
+    <refine patch="1" u="19" v="19"/>
+  </geometry>
+
+  <discretization>
+    <nGauss>3 5</nGauss>
+  </discretization>
+
+  <geometry>
+    <topologysets>
+      <set name="boundary" type="edge">
+        <item patch="1">1 2 3 4</item>
+      </set>
+      <set name="plate" type="surface">
+        <item>1</item>
+      </set>
+    </topologysets>
+  </geometry>
+
+  <boundaryconditions>
+    <dirichlet set="boundary" comp="1"/>
+  </boundaryconditions>
+
+  <kirchhofflove>
+    <isotropic E="1.0" nu="0.3" thickness="1.0"/>
+    <lineload set="plate" type="constant" u="0.5" v0="0.25" v1="0.75">2.0</lineload>
+  </kirchhofflove>
+
+  <postprocessing>
+    <resultpoints>
+      <point patch="1" u="0.5" v="0.5"/>
+    </resultpoints>
+  </postprocessing>
+
+</simulation>

--- a/Linear/Test/PointLoadedPlate-project-file.reg
+++ b/Linear/Test/PointLoadedPlate-project-file.reg
@@ -34,7 +34,6 @@ Parsing <postprocessing>
 	Point 2: P1 xi = 0.5 0.25
 	Point 3: P1 xi = 0.25 0.5
 	Point 4: P1 xi = 0.25 0.25
-Parsing <adaptive>
 Parsing input file succeeded.
 Equation solver: 2
 Number of Gauss points: 4

--- a/Linear/Test/PointLoadedPlate-project-file.xinp
+++ b/Linear/Test/PointLoadedPlate-project-file.xinp
@@ -39,14 +39,4 @@
     </resultpoints>
   </postprocessing>
 
-  <adaptive>
-    <maxstep>3</maxstep>
-    <beta type="maximum">90</beta>
-    <maxdof>100000</maxdof>
-    <errtol>0.0001</errtol>
-    <knot_mult>1</knot_mult>
-    <scheme>isotropic_function</scheme>
-    <use_norm>1</use_norm>
-  </adaptive>
-
 </simulation>


### PR DESCRIPTION
This adds the functionality of specifying a line load in the interior of the domain of a KL-plate problem.
It is restricted to follow the element interfaces (horizontal or vertical), and only one load per patch.
It uses the element interface integrand framework, and requires OPM/IFEM#300 containing some extension/bugfixes of that.

The current implementation is still a bit hackish, but seems to work at least. The parameters defining the location of the line load is currently hard-coded. This needs to be specified via the input file, later.
