### PR TITLE
Account for pure 2D geometry for cable and bar problems

### DIFF
--- a/Beam/ElasticBar.h
+++ b/Beam/ElasticBar.h
@@ -72,6 +72,18 @@ public:
   virtual bool evalInt(LocalIntegral& elmInt, const FiniteElement& fe,
                        const Vec3&) const;
 
+  using ElasticBase::finalizeElement;
+  //! \brief Finalizes the element matrices after the numerical integration.
+  //! \param elmInt The local integral object to receive the contributions
+  //! \param[in] fe Nodal and integration point data for current element
+  //! \param[in] time Parameters for nonlinear and time-dependent simulations
+  //! \param[in] iGP Global integration point counter of first point in element
+  //!
+  //! \details This method is used to shrink the element matrices
+  //! in the case of two-dimensional geometry with two DOFs per node.
+  virtual bool finalizeElement(LocalIntegral& elmInt, const FiniteElement& fe,
+                               const TimeDomain& time, size_t iGP);
+
 private:
   //! \brief Evaluates the axial strain.
   //! \param[in] LoverL0 Current length over initial length ratio

--- a/Beam/ElasticCable.C
+++ b/Beam/ElasticCable.C
@@ -114,11 +114,11 @@ bool ElasticCable::evalInt (LocalIntegral& elmInt,
   Vec3   x(X);
   Vec3  dx(dX);
   Vec3 ddx(ddX);
-  for (i = 0; i < 3; i++)
+  for (i = 0; i < npv; i++)
   {
-      x[i] += eV.dot(fe.N,i,3);
-     dx[i] += eV.dot(fe.dNdX,i,3);
-    ddx[i] += eV.dot(fe.d2NdX2,i,3);
+      x[i] += eV.dot(fe.N,i,npv);
+     dx[i] += eV.dot(fe.dNdX,i,npv);
+    ddx[i] += eV.dot(fe.d2NdX2,i,npv);
   }
 #if INT_DEBUG > 1
   std::cout <<"ElasticCable: x = "<< x <<" dx = "<< dx <<" ddx = "<< ddx <<"\n";
@@ -128,14 +128,18 @@ bool ElasticCable::evalInt (LocalIntegral& elmInt,
 
   Vec3 B_unit, N_unit;
   double B_len, N_len;
-  if (!evalLocalAxes(dX,ddX,B_unit,N_unit,B_len,N_len)) return false;
+  if (!evalLocalAxes(dX,ddX,B_unit,N_unit,B_len,N_len))
+    return false;
+
 #if INT_DEBUG > 1
   std::cout <<"ElasticCable: B_unit = "<< B_unit <<" N_unit = "<< N_unit <<"\n";
 #endif
 
   Vec3 b_unit, n_unit;
   double b_len, n_len;
-  if (!evalLocalAxes(dx,ddx,b_unit,n_unit,b_len,n_len)) return false;
+  if (!evalLocalAxes(dx,ddx,b_unit,n_unit,b_len,n_len))
+    return false;
+
   Vec3   bin    = b_unit * b_len;
   double b_len2 = b_len  * b_len;
   Vec3   n      = n_unit * n_len;
@@ -450,7 +454,7 @@ bool ElasticCable::evalSol (Vector& s, const FiniteElement& fe, const Vec3& X,
   Vector eV;
   if (!primsol.empty() && !primsol.front().empty())
   {
-    int ierr = utl::gather(MNPC,3,primsol.front(),eV);
+    int ierr = utl::gather(MNPC,npv,primsol.front(),eV);
     if (ierr > 0)
     {
       std::cerr <<" *** ElasticCable::evalSol: Detected "<< ierr
@@ -467,11 +471,11 @@ bool ElasticCable::evalSol (Vector& s, const FiniteElement& fe, const Vec3& X,
   Vec3   x(X);
   Vec3  dx(dX);
   Vec3 ddx(ddX);
-  for (size_t i = 0; i < 3; i++)
+  for (size_t i = 0; i < npv; i++)
   {
-      x[i] += eV.dot(fe.N,i,3);
-     dx[i] += eV.dot(fe.dNdX,i,3);
-    ddx[i] += eV.dot(fe.d2NdX2,i,3);
+      x[i] += eV.dot(fe.N,i,npv);
+     dx[i] += eV.dot(fe.dNdX,i,npv);
+    ddx[i] += eV.dot(fe.d2NdX2,i,npv);
   }
 #if INT_DEBUG > 1
   std::cout <<"ElasticCable: X = "<< X <<" u = "<< X-x <<"\n";

--- a/Beam/ElasticCable.h
+++ b/Beam/ElasticCable.h
@@ -31,9 +31,10 @@ class ElasticCable : public ElasticBar
 {
 public:
   //! \brief Default constructor.
-  //! \param[in] n Number of consequtive solution vectors to reside in core
-  explicit ElasticCable(unsigned short int n = 1) : ElasticBar('G',3,n),
-    EA(stiffness), EI(0.0) {}
+  //! \param[in] nd Number of primary unknowns per node
+  //! \param[in] ns Number of consequtive solution vectors to reside in core
+  explicit ElasticCable(unsigned short int nd = 3, unsigned short int ns = 1)
+    : ElasticBar('G',nd,ns), EA(stiffness), EI(0.0) {}
   //! \brief Empty destructor.
   virtual ~ElasticCable() {}
 
@@ -65,11 +66,11 @@ public:
 
   //! \brief Returns the number of primary/secondary solution field components.
   //! \param[in] fld which field set to consider (1=primary, 2=secondary)
-  virtual size_t getNoFields(int fld = 2) const { return fld == 1 ? 3 : 2; }
+  virtual size_t getNoFields(int fld) const { return fld == 1 ? 3 : 2; }
   //! \brief Returns the name of a secondary solution field component.
   //! \param[in] i Field component index
   //! \param[in] prefix Name prefix for all components
-  virtual std::string getField2Name(size_t i, const char* prefix = nullptr) const;
+  virtual std::string getField2Name(size_t i, const char* prefix) const;
 
 private:
   double& EA; //!< Axial stiffness

--- a/Linear/Test/Cantilever-Cable3p.reg
+++ b/Linear/Test/Cantilever-Cable3p.reg
@@ -11,8 +11,7 @@ Parsing <geometry>
   Parsing <raiseorder>
   Parsing <refine>
   Parsing <topologysets>
-	Topology sets: all (1,0,1D)
-	               innspenning (1,1,0D)
+	Topology sets: innspenning (1,1,0D)
   Parsing <raiseorder>
 	Raising order of P1 2
   Parsing <refine>
@@ -20,9 +19,7 @@ Parsing <geometry>
   Parsing <topologysets>
 Parsing <boundaryconditions>
   Parsing <dirichlet>
-	Dirichlet code 3: (fixed)
-  Parsing <dirichlet>
-	Dirichlet code 23123: (fixed)
+	Dirichlet code 2012: (fixed)
 Parsing <cable>
   Parsing <material>
 	Axial stiffness = 785398
@@ -37,12 +34,11 @@ Spline basis with C1-continuous patch interfaces is used
 Problem definition:
 ElasticCable: Stiffness = 785398 490.874, Mass density = 7850
 Resolving Dirichlet boundary conditions
-	Constraining P1 V1 in direction(s) 23123
-	Constraining P1 in direction(s) 3
+	Constraining P1 V1 in direction(s) 2012
  >>> SAM model summary <<<
 Number of elements    10
 Number of nodes       13
-Number of dofs        39
+Number of dofs        26
 Number of unknowns    23
 Number of quadrature points 40
 Processing integrand associated with code 0
@@ -50,5 +46,5 @@ Assembling interior matrix terms for P1
 Solving the equation system ...
 	Condition number: 137427
  >>> Solution summary <<<
-L2-norm            : 0.0211263
+L2-norm            : 0.0258744
 Max Y-displacement : 0.0679061

--- a/Linear/Test/Cantilever-Cable3p.xinp
+++ b/Linear/Test/Cantilever-Cable3p.xinp
@@ -4,13 +4,10 @@
 
 <simulation>
 
-  <geometry>
+  <geometry dim="2">
     <raiseorder patch="1" u="2"/>
     <refine patch="1" u="9"/>
     <topologysets>
-      <set name="all" type="curve">
-        <item patch="1"/>
-      </set>
       <set name="innspenning" type="vertex">
         <item patch="1">1</item>
       </set>
@@ -18,8 +15,7 @@
   </geometry>
 
   <boundaryconditions>
-    <dirichlet set="all" comp="3"/>
-    <dirichlet set="innspenning" comp="23123"/>
+    <dirichlet set="innspenning" comp="2012"/>
   </boundaryconditions>
 
   <cable>

--- a/Linear/Test/SS45-Cable4p.reg
+++ b/Linear/Test/SS45-Cable4p.reg
@@ -4,13 +4,15 @@ Input file: SS45-Cable4p.xinp
 Equation solver: 2
 Number of Gauss points: 5
 Spline basis with C1-continuous patch interfaces is used
+Solution component output zero tolerance: 1e-06
 Parsing input file SS45-Cable4p.xinp
 Parsing <geometry>
+  Generating linear geometry on unit parameter domain \[0,1]
+	X1 = 1.0 1.0
   Parsing <raiseorder>
   Parsing <refine>
   Parsing <topologysets>
-	Topology sets: all (1,0,1D)
-	               ends (1,1,0D) (1,2,0D)
+	Topology sets: ends (1,1,0D) (1,2,0D)
   Parsing <raiseorder>
 	Raising order of P1 3
   Parsing <refine>
@@ -18,9 +20,7 @@ Parsing <geometry>
   Parsing <topologysets>
 Parsing <boundaryconditions>
   Parsing <dirichlet>
-	Dirichlet code 3: (fixed)
-  Parsing <dirichlet>
-	Dirichlet code 123: (fixed)
+	Dirichlet code 12: (fixed)
 Parsing <cable>
   Parsing <gravity>
 	Gravitation vector: 0 -9.81 0
@@ -40,27 +40,28 @@ Spline basis with C1-continuous patch interfaces is used
 Problem definition:
 ElasticCable: Stiffness = 7.85398e+08 490873, Mass density = 235.619
 Resolving Dirichlet boundary conditions
-	Constraining P1 V1 in direction(s) 123
-	Constraining P1 V2 in direction(s) 123
-	Constraining P1 in direction(s) 3
+	Constraining P1 V1 in direction(s) 12
+	Constraining P1 V2 in direction(s) 12
 Result point #1: patch #1 u=0.25, node #5, X = 0.25 0.25 0
 Result point #2: patch #1 u=0.5, X = 0.5 0.5 0
 Result point #3: patch #1 u=0.75, node #10, X = 0.75 0.75 0
  >>> SAM model summary <<<
 Number of elements    10
 Number of nodes       14
-Number of dofs        42
+Number of dofs        28
 Number of unknowns    24
+Number of quadrature points 50
 Processing integrand associated with code 0
 Assembling interior matrix terms for P1
 Solving the equation system ...
+	Condition number: 11313.2
  >>> Solution summary <<<
-L2-norm            : 6.17504e-05
+L2-norm            : 7.56284e-05
 Max X-displacement : 0.000123236
 Max Y-displacement : 0.000123976
-  Node #5:	sol1 =  8.709439e-05 -8.764620e-05  0.000000e+00
+  Node #5:	sol1 =  8.709439e-05 -8.764620e-05
 		sol2 = -1.098551e+03  6.129089e+02
-  Point #2:	sol1 =  1.222571e-04 -1.229929e-04  0.000000e+00
+  Point #2:	sol1 =  1.222571e-04 -1.229929e-04
 		sol2 =  0.000000e+00  8.172112e+02
-  Node #10:	sol1 =  8.709439e-05 -8.764620e-05  0.000000e+00
+  Node #10:	sol1 =  8.709439e-05 -8.764620e-05
 		sol2 =  1.212872e+03  6.129078e+02

--- a/Linear/Test/SS45-Cable4p.xinp
+++ b/Linear/Test/SS45-Cable4p.xinp
@@ -5,13 +5,10 @@
 
 <simulation>
 
-  <geometry X1="1.0 1.0 0.0">
+  <geometry dim="2" X1="1.0 1.0">
     <raiseorder patch="1" u="3"/>
     <refine patch="1" u="9"/>
     <topologysets>
-      <set name="all" type="curve">
-        <item patch="1"/>
-      </set>
       <set name="ends" type="vertex">
         <item patch="1">1 2</item>
       </set>
@@ -19,8 +16,7 @@
   </geometry>
 
   <boundaryconditions>
-    <dirichlet set="all" comp="3"/>
-    <dirichlet set="ends" comp="123"/>
+    <dirichlet set="ends" comp="12"/>
   </boundaryconditions>
 
   <cable>

--- a/Linear/Test/SScablePointLoad.reg
+++ b/Linear/Test/SScablePointLoad.reg
@@ -11,8 +11,7 @@ Parsing <geometry>
   Parsing <raiseorder>
   Parsing <refine>
   Parsing <topologysets>
-	Topology sets: all (1,0,1D)
-	               ends (1,1,0D) (1,2,0D)
+	Topology sets: ends (1,1,0D) (1,2,0D)
   Parsing <raiseorder>
 	Raising order of P1 2
   Parsing <refine>
@@ -20,9 +19,7 @@ Parsing <geometry>
   Parsing <topologysets>
 Parsing <boundaryconditions>
   Parsing <dirichlet>
-	Dirichlet code 3: (fixed)
-  Parsing <dirichlet>
-	Dirichlet code 123: (fixed)
+	Dirichlet code 12: (fixed)
 Parsing <cable>
   Parsing <material>
 	Axial stiffness = 0.012
@@ -40,14 +37,13 @@ Spline basis with C1-continuous patch interfaces is used
 Problem definition:
 ElasticCable: Stiffness = 0.012 1e-07, Mass density = 7850
 Resolving Dirichlet boundary conditions
-	Constraining P1 V1 in direction(s) 123
-	Constraining P1 V2 in direction(s) 123
-	Constraining P1 in direction(s) 3
+	Constraining P1 V1 in direction(s) 12
+	Constraining P1 V2 in direction(s) 12
 Result point #1: patch #1 u=0.5, node #4, X = 0.5 0 0
  >>> SAM model summary <<<
 Number of elements    4
 Number of nodes       7
-Number of dofs        21
+Number of dofs        14
 Number of unknowns    10
 Load point #1: patch #1 u=0.5 on element #3 (u=0.5), X = 0.5 0 0
 Number of quadrature points 16
@@ -56,7 +52,7 @@ Assembling interior matrix terms for P1
 Solving the equation system ...
 	Condition number: 65.929
  >>> Solution summary <<<
-L2-norm            : 72106.1
+L2-norm            : 88311.6
 Max Y-displacement : 234375
-  Node #4:	sol1 =  0.000000e+00  2.083333e+05  0.000000e+00
+  Node #4:	sol1 =  0.000000e+00  2.083333e+05
 		sol2 =  0.000000e+00  2.500000e-01

--- a/Linear/Test/SScablePointLoad.xinp
+++ b/Linear/Test/SScablePointLoad.xinp
@@ -5,13 +5,10 @@
 
 <simulation>
 
-  <geometry>
+  <geometry dim="2">
     <raiseorder patch="1" u="2"/>
     <refine patch="1" u="3"/>
     <topologysets>
-      <set name="all" type="curve">
-        <item patch="1"/>
-      </set>
       <set name="ends" type="vertex">
         <item patch="1">1 2</item>
       </set>
@@ -19,8 +16,7 @@
   </geometry>
 
   <boundaryconditions>
-    <dirichlet set="all" comp="3"/>
-    <dirichlet set="ends" comp="123"/>
+    <dirichlet set="ends" comp="12"/>
   </boundaryconditions>
 
   <cable>


### PR DESCRIPTION
If the g2-file is 2D, nsd is reset to 2 and we need only 2 DOFs per node.

Requires OPM/IFEM#326