### PR TITLE
Support for moment load on C1 cable elements

### DIFF
--- a/Beam/ElasticBar.C
+++ b/Beam/ElasticBar.C
@@ -33,15 +33,14 @@ ElasticBar::ElasticBar (char strm, unsigned short int nd, unsigned short int ns)
 
 void ElasticBar::printLog () const
 {
-  utl::LogStream& os = IFEM::cout;
-
-  os <<"ElasticBar: Stiffness = "<< stiffness <<", Mass = "<< lineMass;
+  IFEM::cout <<"ElasticBar: Stiffness = "<< stiffness
+             <<", Mass/length = "<< lineMass;
   switch (strain_meassure) {
-  case 'E': os <<", Engineering strain"; break;
-  case 'G': os <<", Green strain"; break;
-  case 'L': os <<", Logarithmic strain"; break;
+  case 'E': IFEM::cout <<", Engineering strain"; break;
+  case 'G': IFEM::cout <<", Green strain"; break;
+  case 'L': IFEM::cout <<", Logarithmic strain"; break;
   }
-  os << std::endl;
+  IFEM::cout << std::endl;
 }
 
 

--- a/Beam/ElasticCable.C
+++ b/Beam/ElasticCable.C
@@ -31,7 +31,7 @@ void ElasticCable::printLog () const
 {
   IFEM::cout <<"ElasticCable: Stiffness = "<< stiffness;
   if (EI > 0.0) IFEM::cout <<" "<< EI;
-  IFEM::cout <<", Mass density = "<< lineMass << std::endl;
+  IFEM::cout <<", Mass/length = "<< lineMass << std::endl;
 }
 
 

--- a/Beam/SIMElasticBar.h
+++ b/Beam/SIMElasticBar.h
@@ -73,6 +73,10 @@ protected:
   //! \brief Preprocessing performed after the FEM model generation.
   virtual bool preprocessB();
 
+  //! \brief Initializes for integration of Neumann terms for a given property.
+  //! \param[in] propInd Physical property index
+  virtual bool initNeumann(size_t propInd);
+
   //! \brief Renumbers all global nodes number if the model.
   //! \param[in] nodeMap Mapping from old to new node number
   virtual bool renumberNodes(const std::map<int,int>& nodeMap);
@@ -96,6 +100,7 @@ private:
   std::vector<PointLoad> myLoads; //!< Nodal/element point loads
 
   mutable bool printed; //!< If \e true, the problem definition as been printed
+  char         lcStiff; //!< Flag for inclusion of load correction stiffness
 
 protected:
   unsigned char nsv; //!< Number of consequtive solution vectors in core

--- a/Linear/Test/Cantilever-Cable3p.reg
+++ b/Linear/Test/Cantilever-Cable3p.reg
@@ -32,7 +32,7 @@ Equation solver: 2
 Number of Gauss points: 4
 Spline basis with C1-continuous patch interfaces is used
 Problem definition:
-ElasticCable: Stiffness = 785398 490.874, Mass density = 7850
+ElasticCable: Stiffness = 785398 490.874, Mass/length = 7850
 Resolving Dirichlet boundary conditions
 	Constraining P1 V1 in direction(s) 2012
  >>> SAM model summary <<<

--- a/Linear/Test/SS45-Cable4p.reg
+++ b/Linear/Test/SS45-Cable4p.reg
@@ -38,7 +38,7 @@ Equation solver: 2
 Number of Gauss points: 5
 Spline basis with C1-continuous patch interfaces is used
 Problem definition:
-ElasticCable: Stiffness = 7.85398e+08 490873, Mass density = 235.619
+ElasticCable: Stiffness = 7.85398e+08 490873, Mass/length = 235.619
 Resolving Dirichlet boundary conditions
 	Constraining P1 V1 in direction(s) 12
 	Constraining P1 V2 in direction(s) 12

--- a/Linear/Test/SScablePointLoad.reg
+++ b/Linear/Test/SScablePointLoad.reg
@@ -35,7 +35,7 @@ Equation solver: 2
 Number of Gauss points: 4
 Spline basis with C1-continuous patch interfaces is used
 Problem definition:
-ElasticCable: Stiffness = 0.012 1e-07, Mass density = 7850
+ElasticCable: Stiffness = 0.012 1e-07, Mass/length = 7850
 Resolving Dirichlet boundary conditions
 	Constraining P1 V1 in direction(s) 12
 	Constraining P1 V2 in direction(s) 12


### PR DESCRIPTION
On kmm's request. The load is implemented as two opposite-directed transverse loads in the two outer-most control points, and with associated load-correction stiffness in nonlinear simulations. Not fully verified yet. It converges, but very slow..

The other commit here is some changes (also on kmm's request) on the interpretation of material data for cables, mostly for avoiding confusion later on. Now you can use the attribute rhoA to specify the mass per length quantity.