### PR TITLE
Added: Surface/edge integration of boundary tractions

### DIFF
--- a/Linear/Test/CanTS2D-p1.reg
+++ b/Linear/Test/CanTS2D-p1.reg
@@ -21,7 +21,6 @@ Parsing <geometry>
 Parsing <boundaryconditions>
   Parsing <dirichlet>
 	Dirichlet code 1: (fixed)
-  Parsing <dirichlet>
 	Dirichlet code 2: (fixed)
   Parsing <neumann>
 	Neumann code 1000000 direction 2 (expression): F0=-1000000; L=2; H=0.4; I=H\*H\*H/12; Y=y/H-0.5; F0\*(H\*H/I)\*(0.5-x/L)\*(0.25-Y\*Y)
@@ -35,6 +34,9 @@ Parsing <elasticity>
 	X0     = 0.4 0 0
 	normal = 1 0 0
 	depth  = 0.4, width = 0
+	comp   = 1
+	comp   = 2
+	comp   = 3
   Parsing <boundaryforce>
 	Boundary force "fixed" code 2000000
 Parsing input file succeeded.
@@ -51,6 +53,7 @@ Number of elements    80
 Number of nodes       105
 Number of dofs        210
 Number of unknowns    204
+Boundary section 1: X0 = 0 0.2 0
 Number of quadrature points 320 8
 Processing integrand associated with code 0
 Assembling interior matrix terms for P1
@@ -69,3 +72,4 @@ Exact error a(e,e)^0.5, e=u-u^h      : 9.38245
 Exact relative error (%) : 18.7925
 Recovered section force a(u^h,w2)    : 1e+06
 Recovered section force a(u^h,w3)    : 1.6e+06
+Boundary tractions at section 1: -407482 -3.77024e+06 -1.87038e+06

--- a/Linear/Test/CanTS2D-p2.reg
+++ b/Linear/Test/CanTS2D-p2.reg
@@ -10,9 +10,6 @@ Parsing <geometry>
   Generating linear geometry on unit parameter domain \[0,1]^2
 	Length in X = 2
 	Length in Y = 0.4
-  Parsing <refine>
-  Parsing <raiseorder>
-  Parsing <refine>
   Parsing <topologysets>
 	Topology sets: fixed (1,1,1D)
   Parsing <refine>
@@ -24,12 +21,9 @@ Parsing <geometry>
   Parsing <topologysets>
 Parsing <boundaryconditions>
   Parsing <fixpoint>
-  Parsing <fixpoint>
-  Parsing <fixpoint>
   Parsing <propertycodes>
   Parsing <neumann>
 	Neumann code 1001 direction 1 (expression): F0=-1000000; L=2; H=0.4; I=H\*H\*H/12; Y=y/H-0.5; -F0\*(L\*H/I)\*Y
-  Parsing <neumann>
 	Neumann code 1002 direction 2 (expression): F0=-1000000; L=2; H=0.4; I=H\*H\*H/12; Y=y/H-0.5; F0\*(H\*H/I)\*(0.5-x/L)\*(0.25-Y\*Y)
 	Constraining P1 point at 0 0 with code 1
 	Constraining P1 point at 0 0.5 with code 12
@@ -44,6 +38,9 @@ Parsing <elasticity>
 	X0     = 0.8 0 0
 	normal = 1 0 0
 	depth  = 0.2, width = 0
+	comp   = 1
+	comp   = 2
+	comp   = 3
   Parsing <boundaryforce>
 	Boundary force "fixed" code 1000000
 Parsing input file succeeded.
@@ -58,6 +55,7 @@ Number of elements    80
 Number of nodes       154
 Number of dofs        308
 Number of unknowns    304
+Boundary section 1: X0 = 0 0.2 0
 Number of quadrature points 900 30
 Processing integrand associated with code 0
 Assembling interior matrix terms for P1
@@ -78,3 +76,4 @@ Exact error a(e,e)^0.5, e=u-u^h      : 0.213733
 Exact relative error (%) : 0.428096
 Recovered section force a(u^h,w2)    : 1e+06
 Recovered section force a(u^h,w3)    : 1.2e+06
+Boundary tractions at section 1: .* -1.02409e+06 -1.99981e+06

--- a/Linear/Test/LR/disc-stair-adap.xinp
+++ b/Linear/Test/LR/disc-stair-adap.xinp
@@ -4,28 +4,20 @@
 
   <!-- General - geometry definitions !-->
   <geometry dim="3">
-		<patchfile>disc-stair-3.g2</patchfile>
-
+    <patchfile>disc-stair-3.g2</patchfile>
     <topology>
       <connection master="1" mface="4" slave="2" sface="3"/>
       <connection master="2" mface="6" slave="3" sface="5"/>
     </topology>
-		<topologysets>
-			<set name="Boundary" type="face">
-				<item patch="3">1 2 3 4 6</item>
-				<item patch="2">1 2 4 5</item>
-				<item patch="1">1 2 3 5 6</item>
-			</set>
-			<set name="Wall" type="face">
-				<item patch="1">3</item>
-			</set>
-		</topologysets>
-
+    <topologysets>
+      <set name="Wall" type="face">
+        <item patch="1">3</item>
+      </set>
+    </topologysets>
   </geometry>
 
   <!-- General - boundary conditions !-->
   <boundaryconditions>
-    <!-- <neumann set="Boundary" type="anasol" comp="1"/> -->
     <dirichlet set="Wall" comp="123"/>
   </boundaryconditions>
 
@@ -38,7 +30,6 @@
     <isotropic E="2.068e11" nu="0.29" rho="7820.0"/>
     <gravity z="-9.81"/>
   </elasticity>
-
 
   <!--General - adaptive refinement parameters -->
   <adaptive>

--- a/Linear/Test/stretch-p1.reg
+++ b/Linear/Test/stretch-p1.reg
@@ -21,7 +21,6 @@ Parsing <geometry>
 Parsing <boundaryconditions>
   Parsing <dirichlet>
 	Dirichlet code 1: (fixed)
-  Parsing <dirichlet>
 	Dirichlet code 2: (fixed)
   Parsing <neumann>
 	Neumann code 1000000 direction 1: 1e+08
@@ -44,6 +43,7 @@ Number of elements    8
 Number of nodes       15
 Number of dofs        30
 Number of unknowns    26
+Boundary section 1: X0 = 0 0.2 0
 Number of quadrature points 32 4
 Processing integrand associated with code 0
 Assembling interior matrix terms for P1
@@ -57,3 +57,4 @@ Max Y-displacement : 6e-05
 Integrating solution norms (FE solution) ...
 Energy norm |u^h| = a(u^h,u^h)^0.5   : 200
 External energy ((f,u^h)+(t,u^h)^0.5 : 200
+Boundary tractions at section 1: -4e+07 .* 8e+06


### PR DESCRIPTION
The traditional way to calculate sectional forces, only at patch boundaries through.
For comparison with the VCP-calculated ones.