### PR TITLE
Quasi-static modal simulation and strain output

### DIFF
--- a/Elasticity.h
+++ b/Elasticity.h
@@ -312,12 +312,14 @@ protected:
   virtual bool pullBackTraction(Vec3&) const { return true; }
 
 public:
-  //! \brief Sets up the inverse constitutive matrix at current point.
-  //! \param[out] Cinv \f$6\times6\f$-matrix (in 3D) or \f$3\times3\f$-matrix
-  //! (in 2D), representing the inverse constitutive tensor
+  //! \brief Sets up the constitutive matrix at current point.
+  //! \param[out] C \f$6\times6\f$-matrix (in 3D) or \f$3\times3\f$-matrix
+  //! (in 2D), representing the constitutive tensor or its inverse
   //! \param[in] fe Finite element data at current point
   //! \param[in] X Cartesian coordinates of current point
-  bool formCinverse(Matrix& Cinv, const FiniteElement& fe, const Vec3& X) const;
+  //! \param[in] inverted If \e true, form the inverse constitutive tensor
+  bool formCmat(Matrix& C, const FiniteElement& fe, const Vec3& X,
+                bool inverted = false) const;
 
   //! \brief Returns \e true if this is an axial-symmetric problem.
   bool isAxiSymmetric() const { return axiSymmetry; }

--- a/Linear/ModalDriver.C
+++ b/Linear/ModalDriver.C
@@ -89,7 +89,8 @@ void ModalDriver::dumpModes (utl::LogStream& os,
 
 
 int modalSim (char* infile, size_t nM, bool dumpModes,
-              SIMoutput* model, DataExporter* exporter)
+              SIMoutput* model, DataExporter* exporter,
+              double zero_tol, std::streamsize outPrec)
 {
   ModalDriver simulator(*model);
 
@@ -136,7 +137,7 @@ int modalSim (char* infile, size_t nM, bool dumpModes,
   }
 
   // Run the modal time integration
-  int status = simulator.solveProblem(exporter,restart);
+  int status = simulator.solveProblem(exporter,restart,zero_tol,outPrec);
 
   delete restart;
   return status;

--- a/Linear/ModalDriver.h
+++ b/Linear/ModalDriver.h
@@ -26,7 +26,9 @@ class ModalDriver : public NewmarkDriver<NewmarkSIM>
 {
 public:
   //! \brief The constructor forwards to the parent class constructor.
-  explicit ModalDriver(SIMbase& sim) : NewmarkDriver<NewmarkSIM>(sim) {}
+  explicit ModalDriver(SIMbase& sim, bool qs = false)
+    : NewmarkDriver<NewmarkSIM>(sim) { qstatic = qs; }
+
   //! \brief Empty destructor.
   virtual ~ModalDriver() {}
 
@@ -48,6 +50,16 @@ public:
 
   //! \brief Dumps the projected secondary solution for the eigenmodes.
   void dumpModes(utl::LogStream& os, std::streamsize precision) const;
+
+  //! \brief Checks whether the corrector iterations have converged or diverged.
+  SIM::ConvStatus checkConvergence(TimeStep& tp);
+  //! \brief Calculates predicted velocities and accelerations.
+  virtual bool predictStep(TimeStep& tp);
+  //! \brief Updates configuration variables (solution vector) in an iteration.
+  virtual bool correctStep(TimeStep& tp, bool);
+
+private:
+  bool qstatic; //!< If \e true, use quasi-static simulation driver
 };
 
 #endif

--- a/Linear/Test/CanTS2D-p2-qstat.reg
+++ b/Linear/Test/CanTS2D-p2-qstat.reg
@@ -1,0 +1,130 @@
+CanTS2D-p2-dyn.xinp -qstatic
+
+Input file: CanTS2D-p2-dyn.xinp
+Equation solver: 2
+Number of Gauss points: 4
+Solution component output zero tolerance: 1e-06
+Parsing input file CanTS2D-p2-dyn.xinp
+Parsing <discretization>
+Parsing <geometry>
+  Generating linear geometry on unit parameter domain \[0,1]^2
+	Length in X = 2
+	Length in Y = 0.4
+  Parsing <refine>
+  Parsing <raiseorder>
+  Parsing <refine>
+  Parsing <refine>
+	Refining P1 0 1
+  Parsing <raiseorder>
+	Raising order of P1 1 1
+  Parsing <refine>
+	Refining P1 7 1
+Parsing <boundaryconditions>
+  Parsing <fixpoint>
+  Parsing <fixpoint>
+  Parsing <fixpoint>
+  Parsing <propertycodes>
+  Parsing <neumann>
+	Neumann code 1001 direction 1 (expression): L=2; H=0.4; I=H\*H\*H/12; Y=y/H-0.5; F0=if(above(t,0.5),0,-1000000)\*sin(3.14159265\*t); F0\*(L\*H/I)\*Y
+  Parsing <neumann>
+	Neumann code 1002 direction 2 (expression): L=2; H=0.4; I=H\*H\*H/12; Y=y/H-0.5; F0=if(above(t,0.5),0,-1000000)\*sin(3.14159265\*t); -F0\*(H\*H/I)\*(0.5-x/L)\*(0.25-Y\*Y)
+	Constraining P1 point at 0 0 with code 1
+	Constraining P1 point at 0 0.5 with code 12
+	Constraining P1 point at 0 1 with code 1
+Parsing <elasticity>
+  Parsing <isotropic>
+	Material code 0: 2.068e+09 0.29 7820
+Parsing <eigensolver>
+Parsing input file succeeded.
+Equation solver: 2
+Eigenproblem solver: 4
+Number of eigenvalues: 10
+Number of Arnoldi vectors: 20
+Shift value: 0
+Number of Gauss points: 3
+Problem definition:
+Elasticity: 2D, gravity = 0 0
+LinIsotropic: plane stress, E = 2.068e+09, nu = 0.29, rho = 7820, alpha = 1.2e-07
+Resolving Dirichlet boundary conditions
+ >>> SAM model summary <<<
+Number of elements    32
+Number of nodes       70
+Number of dofs        140
+Number of unknowns    136
+Number of quadrature points 360 30
+Processing integrand associated with code 0
+Assembling interior matrix terms for P1
+Solving the eigenvalue problem ...
+  EIG_DRV4
+  ========
+  Size of the matrix is          136
+  The number of Ritz values requested is           10
+  The number of Arnoldi vectors generated (NCV) is           20
+  What portion of the spectrum: LM
+  The number of converged Ritz values is           10
+  The number of Implicit Arnoldi update iterations taken is            5
+  The number of OP\*x is           42
+ >>> Computed Eigenvalues <<<
+     Mode	Frequency \[Hz]
+     1		7.18604
+     2		40.4067
+     3		58.8172
+     4		98.6518
+     5		166.762
+     6		176.523
+     7		241.19
+     8		293.906
+     9		320.581
+     10		400.917
+Parsing input file CanTS2D-p2-dyn.xinp
+Parsing <newmarksolver>
+	alpha1 = 0  alpha2 = 0
+	beta = 0.25  gamma = 0.5
+Parsing input file succeeded.
+Problem definition:
+Elasticity: 2D, gravity = 0 0
+LinIsotropic: plane stress, E = 2.068e+09, nu = 0.29, rho = 7820, alpha = 1.2e-07
+Quasi-static linear analysis.
+  step=1  time=0.05
+  Displacement L2-norm            : 0.0148717
+               Max X-displacement : 0.00568683
+               Max Y-displacement : 0.038807
+  step=2  time=0.1
+  Displacement L2-norm            : 0.0293773
+               Max X-displacement : 0.0112336
+               Max Y-displacement : 0.0766585
+  step=3  time=0.15
+  Displacement L2-norm            : 0.0431595
+               Max X-displacement : 0.0165038
+               Max Y-displacement : 0.112622
+  step=4  time=0.2
+  Displacement L2-norm            : 0.0558789
+               Max X-displacement : 0.0213676
+               Max Y-displacement : 0.145813
+  step=5  time=0.25
+  Displacement L2-norm            : 0.0672224
+               Max X-displacement : 0.0257053
+               Max Y-displacement : 0.175414
+  step=6  time=0.3
+  Displacement L2-norm            : 0.0769107
+               Max X-displacement : 0.02941
+               Max Y-displacement : 0.200695
+  step=7  time=0.35
+  Displacement L2-norm            : 0.0847052
+               Max X-displacement : 0.0323906
+               Max Y-displacement : 0.221034
+  step=8  time=0.4
+  Displacement L2-norm            : 0.090414
+               Max X-displacement : 0.0345736
+               Max Y-displacement : 0.235931
+  step=9  time=0.45
+  Displacement L2-norm            : 0.0938964
+               Max X-displacement : 0.0359052
+               Max Y-displacement : 0.245018
+  step=10  time=0.5
+  Displacement L2-norm            : 0.0950669
+               Max X-displacement : 0.0363528
+               Max Y-displacement : 0.248072
+  step=11  time=0.55
+  Displacement L2-norm            : 0
+  Time integration completed.

--- a/Linear/main_LinEl.C
+++ b/Linear/main_LinEl.C
@@ -34,6 +34,7 @@
   \param[in] infile The input file to parse for time integration setup
   \param[in] nM Number of eigenmodes
   \param[in] dumpModes If \e true, dump projected eigenmode solutions
+  \param[in] qstatic If \e true, use quasi-static simulation mode
   \param model The isogeometric finite element model
   \param exporter Result export handler
   \param[in] zero_tol Truncate result values smaller than this to zero
@@ -41,7 +42,7 @@
   \return Exit status
 */
 
-int modalSim (char* infile, size_t nM, bool dumpModes,
+int modalSim (char* infile, size_t nM, bool dumpModes, bool qStatic,
               SIMoutput* model, DataExporter* exporter,
               double zero_tol, std::streamsize outPrec);
 
@@ -81,6 +82,7 @@ int modalSim (char* infile, size_t nM, bool dumpModes,
   \arg -shift \a shf : Shift value to use in the eigenproblem solver
   \arg -free : Ignore all boundary conditions (use in free vibration analysis)
   \arg -dynamic : Solve the linear dynamics problem using modal transformation
+  \arg -qstatic : Solve the linear dynamics problem as quasi-static
   \arg -dumpModes : Dump projected eigenmode solution
   \arg -strain : Output strains instead of stresses to VTF and result points
   \arg -check : Data check only, read model and output to VTF (no solution)
@@ -128,7 +130,7 @@ int main (int argc, char** argv)
   bool noProj = false;
   bool noError = false;
   bool dualSol = false;
-  bool dynSol = false;
+  char dynSol = false;
   bool dumpModes = false;
   char* infile = nullptr;
   Elasticity::wantStrain = false;
@@ -212,7 +214,9 @@ int main (int argc, char** argv)
     else if (!strncmp(argv[i],"-dual",5))
       dualSol = true;
     else if (!strncmp(argv[i],"-dyn",4))
-      dynSol = true;
+      dynSol = 'd';
+    else if (!strncmp(argv[i],"-qstat",6))
+      dynSol = 's';
     else if (!strcmp(argv[i],"-dumpModes"))
       dumpModes = true;
     else if (!infile)
@@ -237,7 +241,7 @@ int main (int argc, char** argv)
               <<" [-nu <nu>] [-nv <nv>] [-nw <nw>]]\n       [-adap[<i>]|-dual"
               <<"adap] [-DGL2] [-CGL2] [-SCR] [-VDSA] [-LSQ] [-QUASI]\n      "
               <<" [-eig <iop> [-nev <nev>] [-ncv <ncv] [-shift <shf>] [-free]]"
-              <<" [-dynamic]\n       [-ignore <p1> <p2> ...] [-fixDup]"
+              <<" [-dynamic|-qstatic]\n       [-ignore <p1> <p2> ...] [-fixDup]"
               <<" [-dual] [-checkRHS] [-check]\n      "
               <<" [-printMax[Patch]] [-dumpASC] [-dumpMatlab [<setnames>]]"
               <<" [-dumpModes]\n       [-outPrec <nd>] [-ztol <eps>] [-strain]"
@@ -689,7 +693,7 @@ int main (int argc, char** argv)
   }
 
   if (dynSol) // Solve the dynamics problem using modal transformation
-    return terminate(modalSim(infile,modes.size(),dumpModes,
+    return terminate(modalSim(infile,modes.size(),dumpModes,dynSol=='s',
                               model,exporter,zero_tol,outPrec));
 
   utl::profiler->start("Postprocessing");

--- a/NewmarkDriver.h
+++ b/NewmarkDriver.h
@@ -189,15 +189,18 @@ protected:
       return 7;
 
     int ip = this->numSolution() - 2;
-    if (!Newmark::model.writeGlvS1(this->realSolution(ip),iStep,
-                                   Newmark::nBlock,params.time.t,
-                                   "velocity",20))
-      return 8;
+    if (ip > 0)
+    {
+      if (!Newmark::model.writeGlvS1(this->realSolution(ip),iStep,
+                                     Newmark::nBlock,params.time.t,
+                                     "velocity",20))
+        return 8;
 
-    if (!Newmark::model.writeGlvS1(this->realSolution(++ip),iStep,
-                                   Newmark::nBlock,params.time.t,
-                                   "acceleration",30))
-      return 9;
+      if (!Newmark::model.writeGlvS1(this->realSolution(++ip),iStep,
+                                     Newmark::nBlock,params.time.t,
+                                     "acceleration",30))
+        return 9;
+    }
 
     if (!Newmark::model.writeGlvP(proSol,iStep,Newmark::nBlock,110,
                                   prefix.c_str()))


### PR DESCRIPTION
* The first commit adds the option to output strains instead of stresses, in result points and VTF.
* The second commit adds the option to perform quasi-static modal simulation.

Requires OPM/IFEM#393.