### PR TITLE
Changed: Use zero tolerance when printing boundary/reaction forces

### DIFF
--- a/Linear/SIMLinEl.h
+++ b/Linear/SIMLinEl.h
@@ -72,7 +72,7 @@ public:
     if (ok && this->getBoundaryReactions(Rforce))
     {
       IFEM::cout <<"Reaction force     :";
-      for (double f : Rforce) IFEM::cout <<" "<< f;
+      for (double f : Rforce) IFEM::cout <<" "<< utl::trunc(f);
       IFEM::cout << std::endl;
     }
 

--- a/Linear/Test/LR/CanTS2D-p1-VCPs.reg
+++ b/Linear/Test/LR/CanTS2D-p1-VCPs.reg
@@ -96,7 +96,7 @@ Projecting secondary solution ...
 	Continuous global L2-projection
 Projecting secondary solution ...
 	Continuous global L2-projection
-Boundary tractions at section 1: 2.79397e-08 -3.70168e+06 -1.90388e+06
+Boundary tractions at section 1: 0 -3.70168e+06 -1.90388e+06
 Energy norm           a(u^h,u^h)^0.5 : 49.1731
 External energy((f,u^h)+(t,u^h))^0.5 : 49.1731
 Exact norm                a(u,u)^0.5 : 49.926

--- a/Linear/main_LinEl.C
+++ b/Linear/main_LinEl.C
@@ -452,19 +452,23 @@ int main (int argc, char** argv)
   };
 
   // Lambda function to calculate and print out boundary forces
-  auto&& printBoundaryForces = [model](const Vector& sol)
+  auto&& printBoundaryForces = [model,zero_tol](const Vector& sol)
   {
     Vectors forces;
     if (!model->calcBouForces(forces,Vectors(1,sol)))
       return false;
 
+    double old_tol = utl::zero_print_tol;
+    if (zero_tol > 0.0) utl::zero_print_tol = zero_tol;
+
     size_t sec = 0;
     for (const Vector& force : forces)
     {
       IFEM::cout <<"\nBoundary tractions at section "<< ++sec <<":";
-      for (double f : force) IFEM::cout <<" "<< f;
+      for (double f : force) IFEM::cout <<" "<< utl::trunc(f);
     }
     IFEM::cout << std::endl;
+    utl::zero_print_tol = old_tol;
     return true;
   };
 


### PR DESCRIPTION
This should resolve the failure of the last memcheck jenkins job