### PR TITLE
Changed: Refactor the analytical solution parsing

### DIFF
--- a/Elasticity.C
+++ b/Elasticity.C
@@ -1073,7 +1073,7 @@ bool ElasticityNorm::evalInt (LocalIntegral& elmInt, const FiniteElement& fe,
   std::cout <<"\nElasticityNorm::evalInt(X = "<< X <<")\nsigma^h ="<< sigmah;
   if (anasol) std::cout <<"sigma ="<< sigma;
   size_t jp = anasol ? 5 : 3;
-  for (size_t i = 0; i < epsz.size(); i++, j += (anasol ? 2 : 1))
+  for (size_t i = 0; i < epsz.size(); i++, jp += (anasol ? 2 : 1))
     std::cout <<"epsz("<< i+1 <<") ="<< epsz[i]
               <<"a(u^,w"<< i+1 <<"): "<< pnorm[jp] << std::endl;
 #endif

--- a/Linear/SIMLinEl2D.C
+++ b/Linear/SIMLinEl2D.C
@@ -15,85 +15,57 @@
 #include "AnalyticSolutions.h"
 
 
-template<> bool SIMLinEl2D::parseDimSpecific (char* keyWord, std::istream& is)
+template<> bool SIMLinEl2D::parseDimSpecific (char* cline)
 {
-  if (!strncasecmp(keyWord,"ANASOL",6)) {
-    int code = -1;
-    char* cline = strtok(keyWord+6," ");
-    if (!strncasecmp(cline,"HOLE",4))
-    {
-      double a  = atof(strtok(NULL," "));
-      double F0 = atof(strtok(NULL," "));
-      double nu = atof(strtok(NULL," "));
-      std::cout <<"\nAnalytical solution: Hole a="<< a <<" F0="<< F0
-		<<" nu="<< nu << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new Hole(a,F0,nu));
-    }
-    else if (!strncasecmp(cline,"LSHAPE",6))
-    {
-      double a  = atof(strtok(NULL," "));
-      double F0 = atof(strtok(NULL," "));
-      double nu = atof(strtok(NULL," "));
-      std::cout <<"\nAnalytical solution: Lshape a="<< a <<" F0="<< F0
-		<<" nu="<< nu << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new Lshape(a,F0,nu));
-    }
-    else if (!strncasecmp(cline,"CANTS",5))
-    {
-      double L  = atof(strtok(NULL," "));
-      double H  = atof(strtok(NULL," "));
-      double F0 = atof(strtok(NULL," "));
-      std::cout <<"\nAnalytical solution: CanTS L="<< L <<" H="<< H
-		<<" F0="<< F0 << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new CanTS(L,H,F0));
-    }
-    else if (!strncasecmp(cline,"CANTM",5))
-    {
-      double H  = atof(strtok(NULL," "));
-      double M0 = atof(strtok(NULL," "));
-      std::cout <<"\nAnalytical solution: CanTM H="<< H
-		<<" M0="<< M0 << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new CanTM(H,M0));
-    }
-    else if (!strncasecmp(cline,"CURVED",6))
-    {
-      double a  = atof(strtok(NULL," "));
-      double b  = atof(strtok(NULL," "));
-      double u0 = atof(strtok(NULL," "));
-      double E  = atof(strtok(NULL," "));
-      std::cout <<"\nAnalytical solution: Curved Beam a="<< a <<" b="<< b
-		<<" u0="<< u0 <<" E="<< E << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new CurvedBeam(u0,a,b,E));
-    }
-    else if (!strncasecmp(cline,"EXPRESSION",10))
-    {
-      std::cout <<"\nAnalytical solution: Expression"<< std::endl;
-      int lines = (cline = strtok(NULL," ")) ? atoi(cline) : 0;
-      code = (cline = strtok(NULL," ")) ? atoi(cline) : 0;
-      if (!mySol)
-        mySol = new AnaSol(is,lines,false);
-    }
-    else
-    {
-      std::cerr <<"  ** SIMLinEl2D::parse: Invalid analytical solution "
-		<< cline <<" (ignored)"<< std::endl;
-      return true;
-    }
-
-    // Define the analytical boundary traction field
-    if (code == -1)
-      code = (cline = strtok(NULL," ")) ? atoi(cline) : 0;
-    if (code > 0 && mySol->getStressSol())
-    {
-      std::cout <<"Pressure code "<< code <<": Analytical traction"<< std::endl;
-      this->setPropertyType(code,Property::NEUMANN);
-      myTracs[code] = new TractionField(*mySol->getStressSol());
-    }
+  if (!strncasecmp(cline,"HOLE",4))
+  {
+    double a  = atof(strtok(nullptr," "));
+    double F0 = atof(strtok(nullptr," "));
+    double nu = atof(strtok(nullptr," "));
+    IFEM::cout <<"\nAnalytical solution: Hole a="<< a <<" F0="<< F0
+               <<" nu="<< nu << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new Hole(a,F0,nu));
+  }
+  else if (!strncasecmp(cline,"LSHAPE",6))
+  {
+    double a  = atof(strtok(nullptr," "));
+    double F0 = atof(strtok(nullptr," "));
+    double nu = atof(strtok(nullptr," "));
+    IFEM::cout <<"\nAnalytical solution: Lshape a="<< a <<" F0="<< F0
+               <<" nu="<< nu << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new Lshape(a,F0,nu));
+  }
+  else if (!strncasecmp(cline,"CANTS",5))
+  {
+    double L  = atof(strtok(nullptr," "));
+    double H  = atof(strtok(nullptr," "));
+    double F0 = atof(strtok(nullptr," "));
+    IFEM::cout <<"\nAnalytical solution: CanTS L="<< L <<" H="<< H
+               <<" F0="<< F0 << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new CanTS(L,H,F0));
+  }
+  else if (!strncasecmp(cline,"CANTM",5))
+  {
+    double H  = atof(strtok(nullptr," "));
+    double M0 = atof(strtok(nullptr," "));
+    IFEM::cout <<"\nAnalytical solution: CanTM H="<< H
+               <<" M0="<< M0 << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new CanTM(H,M0));
+  }
+  else if (!strncasecmp(cline,"CURVED",6))
+  {
+    double a  = atof(strtok(nullptr," "));
+    double b  = atof(strtok(nullptr," "));
+    double u0 = atof(strtok(nullptr," "));
+    double E  = atof(strtok(nullptr," "));
+    IFEM::cout <<"\nAnalytical solution: Curved Beam a="<< a <<" b="<< b
+               <<" u0="<< u0 <<" E="<< E << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new CurvedBeam(u0,a,b,E));
   }
   else
     return false;
@@ -102,99 +74,83 @@ template<> bool SIMLinEl2D::parseDimSpecific (char* keyWord, std::istream& is)
 }
 
 
-template<> bool SIMLinEl2D::parseDimSpecific (const TiXmlElement* child)
+template<> bool SIMLinEl2D::parseDimSpecific (const TiXmlElement* child,
+                                              const std::string& type)
 {
-  if (!strcasecmp(child->Value(),"anasol")) {
-    std::string type;
-    utl::getAttribute(child,"type",type,true);
-    if (type == "hole") {
-      double a = 0.0, F0 = 0.0, nu = 0.0;
-      utl::getAttribute(child,"a",a);
-      utl::getAttribute(child,"F0",F0);
-      utl::getAttribute(child,"nu",nu);
-      IFEM::cout <<"\tAnalytical solution: Hole a="<< a <<" F0="<< F0
-                 <<" nu="<< nu << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new Hole(a,F0,nu));
-    }
-    else if (type == "lshape") {
-      double a = 0.0, F0 = 0.0, nu = 0.0;
-      utl::getAttribute(child,"a",a);
-      utl::getAttribute(child,"F0",F0);
-      utl::getAttribute(child,"nu",nu);
-      IFEM::cout <<"\tAnalytical solution: Lshape a="<< a <<" F0="<< F0
-                 <<" nu="<< nu << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new Lshape(a,F0,nu));
-    }
-    else if (type == "cants") {
-      double L = 0.0, H = 0.0, F0 = 0.0;
-      utl::getAttribute(child,"L",L);
-      utl::getAttribute(child,"H",H);
-      utl::getAttribute(child,"F0",F0);
-      IFEM::cout <<"\tAnalytical solution: CanTS L="<< L <<" H="<< H
-                 <<" F0="<< F0 << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new CanTS(L,H,F0));
-    }
-    else if (type == "cantm") {
-      double L = 0.0, H = 0.0, M0 = 0.0;
-      utl::getAttribute(child,"L",L);
-      utl::getAttribute(child,"H",H);
-      utl::getAttribute(child,"M0",M0);
-      IFEM::cout <<"\tAnalytical solution: CanTM H="<< H
-                 <<" M0="<< M0 << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new CanTM(H,M0));
-    }
-    else if (type == "curved") {
-      double a = 0.0, b = 0.0, u0 = 0.0, E = 0.0;
-      utl::getAttribute(child,"a",a);
-      utl::getAttribute(child,"b",b);
-      utl::getAttribute(child,"u0",u0);
-      utl::getAttribute(child,"E",E);
-      IFEM::cout <<"\tAnalytical solution: Curved Beam a="<< a <<" b="<< b
-                 <<" u0="<< u0 <<" E="<< E << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new CurvedBeam(u0,a,b,E));
-    }
-    else if (type == "pipe") {
-      double Ri = 0.0, Ro = 0.0, Ti = 0.0, To = 0.0, T0 = 273.0;
-      double E = 0.0, nu = 0.0, alpha = 0.0;
-      bool polar = false;
-      utl::getAttribute(child,"Ri",Ri);
-      utl::getAttribute(child,"Ro",Ro);
-      utl::getAttribute(child,"Ti",Ti);
-      utl::getAttribute(child,"To",To);
-      utl::getAttribute(child,"Tref",T0);
-      utl::getAttribute(child,"E",E);
-      utl::getAttribute(child,"nu",nu);
-      utl::getAttribute(child,"alpha",alpha);
-      utl::getAttribute(child,"polar",polar);
-      IFEM::cout <<"\tAnalytical solution: Pipe Ri="<< Ri <<" Ro="<< Ro
-                 <<" Ti="<< Ti <<" To="<< To << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new Pipe(Ri,Ro,Ti,To,T0,E,nu,alpha,false,polar));
-    }
-    else if (type == "expression" || type == "fields") {
-      type[0] = toupper(type[0]);
-      IFEM::cout <<"\tAnalytical solution: "<< type << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(child,false);
-    }
-    else
-      std::cerr <<"  ** SIMLinEl2D::parse: Invalid analytical solution "
-                << type <<" (ignored)"<< std::endl;
-
-    // Define the analytical boundary traction field
-    int code = 0;
-    utl::getAttribute(child,"code",code);
-    if (code > 0 && mySol && mySol->getStressSol()) {
-      IFEM::cout <<"\tNeumann code "<< code
-                 <<": Analytical traction"<< std::endl;
-      this->setPropertyType(code,Property::NEUMANN);
-      myTracs[code] = new TractionField(*mySol->getStressSol());
-    }
+  if (type == "hole")
+  {
+    double a = 0.0, F0 = 0.0, nu = 0.0;
+    utl::getAttribute(child,"a",a);
+    utl::getAttribute(child,"F0",F0);
+    utl::getAttribute(child,"nu",nu);
+    IFEM::cout <<"\tAnalytical solution: Hole a="<< a <<" F0="<< F0
+               <<" nu="<< nu << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new Hole(a,F0,nu));
+  }
+  else if (type == "lshape")
+  {
+    double a = 0.0, F0 = 0.0, nu = 0.0;
+    utl::getAttribute(child,"a",a);
+    utl::getAttribute(child,"F0",F0);
+    utl::getAttribute(child,"nu",nu);
+    IFEM::cout <<"\tAnalytical solution: Lshape a="<< a <<" F0="<< F0
+               <<" nu="<< nu << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new Lshape(a,F0,nu));
+  }
+  else if (type == "cants")
+  {
+    double L = 0.0, H = 0.0, F0 = 0.0;
+    utl::getAttribute(child,"L",L);
+    utl::getAttribute(child,"H",H);
+    utl::getAttribute(child,"F0",F0);
+    IFEM::cout <<"\tAnalytical solution: CanTS L="<< L <<" H="<< H
+               <<" F0="<< F0 << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new CanTS(L,H,F0));
+  }
+  else if (type == "cantm")
+  {
+    double L = 0.0, H = 0.0, M0 = 0.0;
+    utl::getAttribute(child,"L",L);
+    utl::getAttribute(child,"H",H);
+    utl::getAttribute(child,"M0",M0);
+    IFEM::cout <<"\tAnalytical solution: CanTM H="<< H
+               <<" M0="<< M0 << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new CanTM(H,M0));
+  }
+  else if (type == "curved")
+  {
+    double a = 0.0, b = 0.0, u0 = 0.0, E = 0.0;
+    utl::getAttribute(child,"a",a);
+    utl::getAttribute(child,"b",b);
+    utl::getAttribute(child,"u0",u0);
+    utl::getAttribute(child,"E",E);
+    IFEM::cout <<"\tAnalytical solution: Curved Beam a="<< a <<" b="<< b
+               <<" u0="<< u0 <<" E="<< E << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new CurvedBeam(u0,a,b,E));
+  }
+  else if (type == "pipe")
+  {
+    double Ri = 0.0, Ro = 0.0, Ti = 0.0, To = 0.0, T0 = 273.0;
+    double E = 0.0, nu = 0.0, alpha = 0.0;
+    bool polar = false;
+    utl::getAttribute(child,"Ri",Ri);
+    utl::getAttribute(child,"Ro",Ro);
+    utl::getAttribute(child,"Ti",Ti);
+    utl::getAttribute(child,"To",To);
+    utl::getAttribute(child,"Tref",T0);
+    utl::getAttribute(child,"E",E);
+    utl::getAttribute(child,"nu",nu);
+    utl::getAttribute(child,"alpha",alpha);
+    utl::getAttribute(child,"polar",polar);
+    IFEM::cout <<"\tAnalytical solution: Pipe Ri="<< Ri <<" Ro="<< Ro
+               <<" Ti="<< Ti <<" To="<< To << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new Pipe(Ri,Ro,Ti,To,T0,E,nu,alpha,false,polar));
   }
   else
     return false;

--- a/Linear/SIMLinEl3D.C
+++ b/Linear/SIMLinEl3D.C
@@ -13,147 +13,101 @@
 
 #include "SIMLinEl.h"
 #include "AnalyticSolutions.h"
-#include "Vec3Oper.h"
 
 
-template<> bool SIMLinEl3D::parseDimSpecific (char* keyWord, std::istream& is)
+template<> bool SIMLinEl3D::parseDimSpecific (char* cline)
 {
-  if (!strncasecmp(keyWord,"ANASOL",6)) {
-    int code = -1;
-    char* cline = strtok(keyWord+6," ");
-    if (!strncasecmp(cline,"HOLE",4))
-    {
-      double a  = atof(strtok(NULL," "));
-      double F0 = atof(strtok(NULL," "));
-      double nu = atof(strtok(NULL," "));
-      IFEM::cout <<"\nAnalytical solution: Hole a="<< a <<" F0="<< F0
-                 <<" nu="<< nu << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new Hole(a,F0,nu,true));
-    }
-    else if (!strncasecmp(cline,"LSHAPE",6))
-    {
-      double a  = atof(strtok(NULL," "));
-      double F0 = atof(strtok(NULL," "));
-      double nu = atof(strtok(NULL," "));
-      IFEM::cout <<"\nAnalytical solution: Lshape a="<< a <<" F0="<< F0
-                 <<" nu="<< nu << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new Lshape(a,F0,nu,true));
-    }
-    else if (!strncasecmp(cline,"CANTS",5))
-    {
-      double L  = atof(strtok(NULL," "));
-      double H  = atof(strtok(NULL," "));
-      double F0 = atof(strtok(NULL," "));
-      IFEM::cout <<"\nAnalytical solution: CanTS L="<< L <<" H="<< H
-                 <<" F0="<< F0 << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new CanTS(L,H,F0,true));
-    }
-    else if (!strncasecmp(cline,"EXPRESSION",10))
-    {
-      IFEM::cout <<"\nAnalytical solution: Expression"<< std::endl;
-      int lines = (cline = strtok(NULL," ")) ? atoi(cline) : 0;
-      code = (cline = strtok(NULL," ")) ? atoi(cline) : 0;
-      if (!mySol)
-        mySol = new AnaSol(is,lines,false);
-    }
-    else
-    {
-      std::cerr <<"  ** SIMLinEl3D::parse: Invalid analytical solution "
-                << cline <<" (ignored)"<< std::endl;
-      return true;
-    }
-
-    // Define the analytical boundary traction field
-    if (code == -1)
-      code = (cline = strtok(NULL," ")) ? atoi(cline) : 0;
-    if (code > 0 && mySol->getStressSol())
-    {
-      IFEM::cout <<"Pressure code "<< code
-                 <<": Analytical traction"<< std::endl;
-      this->setPropertyType(code,Property::NEUMANN);
-      myTracs[code] = new TractionField(*mySol->getStressSol());
-    }
+  if (!strncasecmp(cline,"HOLE",4))
+  {
+    double a  = atof(strtok(nullptr," "));
+    double F0 = atof(strtok(nullptr," "));
+    double nu = atof(strtok(nullptr," "));
+    IFEM::cout <<"\nAnalytical solution: Hole a="<< a <<" F0="<< F0
+               <<" nu="<< nu << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new Hole(a,F0,nu,true));
   }
+  else if (!strncasecmp(cline,"LSHAPE",6))
+  {
+    double a  = atof(strtok(nullptr," "));
+    double F0 = atof(strtok(nullptr," "));
+    double nu = atof(strtok(nullptr," "));
+    IFEM::cout <<"\nAnalytical solution: Lshape a="<< a <<" F0="<< F0
+               <<" nu="<< nu << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new Lshape(a,F0,nu,true));
+  }
+  else if (!strncasecmp(cline,"CANTS",5))
+  {
+    double L  = atof(strtok(nullptr," "));
+    double H  = atof(strtok(nullptr," "));
+    double F0 = atof(strtok(nullptr," "));
+    IFEM::cout <<"\nAnalytical solution: CanTS L="<< L <<" H="<< H
+               <<" F0="<< F0 << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new CanTS(L,H,F0,true));
+  }
+  else
+    return false;
 
-  return false;
+  return true;
 }
 
 
-template<> bool SIMLinEl3D::parseDimSpecific (const TiXmlElement* child)
+template<> bool SIMLinEl3D::parseDimSpecific (const TiXmlElement* child,
+                                              const std::string& type)
 {
-  if (!strcasecmp(child->Value(),"anasol")) {
-    std::string type;
-    utl::getAttribute(child,"type",type,true);
-    if (type == "hole") {
-      double a = 0.0, F0 = 0.0, nu = 0.0;
-      utl::getAttribute(child,"a",a);
-      utl::getAttribute(child,"F0",F0);
-      utl::getAttribute(child,"nu",nu);
-      IFEM::cout <<"\tAnalytical solution: Hole a="<< a <<" F0="<< F0
-                 <<" nu="<< nu << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new Hole(a,F0,nu,true));
-    }
-    else if (type == "lshape") {
-      double a = 0.0, F0 = 0.0, nu = 0.0;
-      utl::getAttribute(child,"a",a);
-      utl::getAttribute(child,"F0",F0);
-      utl::getAttribute(child,"nu",nu);
-      IFEM::cout <<"\tAnalytical solution: Lshape a="<< a <<" F0="<< F0
-                 <<" nu="<< nu << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new Lshape(a,F0,nu,true));
-    }
-    else if (type == "cants") {
-      double L = 0.0, H = 0.0, F0 = 0.0;
-      utl::getAttribute(child,"L",L);
-      utl::getAttribute(child,"H",H);
-      utl::getAttribute(child,"F0",F0);
-      IFEM::cout <<"\tAnalytical solution: CanTS L="<< L <<" H="<< H
-                 <<" F0="<< F0 << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new CanTS(L,H,F0,true));
-    }
-    else if (type == "pipe") {
-      double Ri = 0.0, Ro = 0.0, Ti = 0.0, To = 0.0, T0 = 273.0;
-      double E = 0.0, nu = 0.0, alpha = 0.0;
-      bool polar = false;
-      utl::getAttribute(child,"Ri",Ri);
-      utl::getAttribute(child,"Ro",Ro);
-      utl::getAttribute(child,"Ti",Ti);
-      utl::getAttribute(child,"To",To);
-      utl::getAttribute(child,"Tref",T0);
-      utl::getAttribute(child,"E",E);
-      utl::getAttribute(child,"nu",nu);
-      utl::getAttribute(child,"alpha",alpha);
-      utl::getAttribute(child,"polar",polar);
-      IFEM::cout <<"\tAnalytical solution: Pipe Ri="<< Ri <<" Ro="<< Ro
-                 <<" Ti="<< Ti <<" To="<< To << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(new Pipe(Ri,Ro,Ti,To,T0,E,nu,alpha,true,polar));
-    }
-    else if (type == "expression" || type == "fields") {
-      type[0] = toupper(type[0]);
-      IFEM::cout <<"\tAnalytical solution: "<< type << std::endl;
-      if (!mySol)
-        mySol = new AnaSol(child,false);
-    }
-    else
-      std::cerr <<"  ** SIMLinEl3D::parse: Invalid analytical solution "
-                << type <<" (ignored)"<< std::endl;
-
-    // Define the analytical boundary traction field
-    int code = 0;
-    utl::getAttribute(child,"code",code);
-    if (code > 0 && mySol && mySol->getStressSol()) {
-      IFEM::cout <<"\tNeumann code "<< code
-                 <<": Analytical traction"<< std::endl;
-      setPropertyType(code,Property::NEUMANN);
-      myTracs[code] = new TractionField(*mySol->getStressSol());
-    }
+  if (type == "hole")
+  {
+    double a = 0.0, F0 = 0.0, nu = 0.0;
+    utl::getAttribute(child,"a",a);
+    utl::getAttribute(child,"F0",F0);
+    utl::getAttribute(child,"nu",nu);
+    IFEM::cout <<"\tAnalytical solution: Hole a="<< a <<" F0="<< F0
+               <<" nu="<< nu << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new Hole(a,F0,nu,true));
+  }
+  else if (type == "lshape")
+  {
+    double a = 0.0, F0 = 0.0, nu = 0.0;
+    utl::getAttribute(child,"a",a);
+    utl::getAttribute(child,"F0",F0);
+    utl::getAttribute(child,"nu",nu);
+    IFEM::cout <<"\tAnalytical solution: Lshape a="<< a <<" F0="<< F0
+               <<" nu="<< nu << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new Lshape(a,F0,nu,true));
+  }
+  else if (type == "cants")
+  {
+    double L = 0.0, H = 0.0, F0 = 0.0;
+    utl::getAttribute(child,"L",L);
+    utl::getAttribute(child,"H",H);
+    utl::getAttribute(child,"F0",F0);
+    IFEM::cout <<"\tAnalytical solution: CanTS L="<< L <<" H="<< H
+               <<" F0="<< F0 << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new CanTS(L,H,F0,true));
+  }
+  else if (type == "pipe")
+  {
+    double Ri = 0.0, Ro = 0.0, Ti = 0.0, To = 0.0, T0 = 273.0;
+    double E = 0.0, nu = 0.0, alpha = 0.0;
+    bool polar = false;
+    utl::getAttribute(child,"Ri",Ri);
+    utl::getAttribute(child,"Ro",Ro);
+    utl::getAttribute(child,"Ti",Ti);
+    utl::getAttribute(child,"To",To);
+    utl::getAttribute(child,"Tref",T0);
+    utl::getAttribute(child,"E",E);
+    utl::getAttribute(child,"nu",nu);
+    utl::getAttribute(child,"alpha",alpha);
+    utl::getAttribute(child,"polar",polar);
+    IFEM::cout <<"\tAnalytical solution: Pipe Ri="<< Ri <<" Ro="<< Ro
+               <<" Ti="<< Ti <<" To="<< To << std::endl;
+    if (!mySol)
+      mySol = new AnaSol(new Pipe(Ri,Ro,Ti,To,T0,E,nu,alpha,true,polar));
   }
   else
     return false;

--- a/Linear/SIMLinElKL.C
+++ b/Linear/SIMLinElKL.C
@@ -34,126 +34,112 @@ KirchhoffLove* SIMLinElKL::getProblem (int version)
 }
 
 
-bool SIMLinElKL::parse (char* keyWord, std::istream& is)
+bool SIMLinElKL::parseAnaSol (char* keyWord, std::istream& is)
 {
-  if (!strncasecmp(keyWord,"ANASOL",6))
+  char* cline = strtok(keyWord+6," ");
+  if (!strncasecmp(cline,"NAVIERPLATE",7))
   {
-    char* cline = strtok(keyWord+6," ");
-    if (!strncasecmp(cline,"NAVIERPLATE",7))
+    double a  = atof(strtok(nullptr," "));
+    double b  = atof(strtok(nullptr," "));
+    double t  = atof(strtok(nullptr," "));
+    double E  = atof(strtok(nullptr," "));
+    double nu = atof(strtok(nullptr," "));
+    double pz = atof(strtok(nullptr," "));
+    IFEM::cout <<"\nAnalytic solution: NavierPlate a="<< a <<" b="<< b
+               <<" t="<< t <<" E="<< E <<" nu="<< nu <<" pz="<< pz;
+    if ((cline = strtok(nullptr," ")))
     {
-      double a  = atof(strtok(NULL," "));
-      double b  = atof(strtok(NULL," "));
-      double t  = atof(strtok(NULL," "));
-      double E  = atof(strtok(NULL," "));
-      double nu = atof(strtok(NULL," "));
-      double pz = atof(strtok(NULL," "));
-      IFEM::cout <<"\nAnalytic solution: NavierPlate a="<< a <<" b="<< b
-                 <<" t="<< t <<" E="<< E <<" nu="<< nu <<" pz="<< pz;
-      if ((cline = strtok(NULL," ")))
+      double xi  = atof(cline);
+      double eta = atof(strtok(nullptr," "));
+      IFEM::cout <<" xi="<< xi <<" eta="<< eta;
+      if ((cline = strtok(nullptr," ")))
       {
-	double xi  = atof(cline);
-	double eta = atof(strtok(NULL," "));
-	IFEM::cout <<" xi="<< xi <<" eta="<< eta;
-	if ((cline = strtok(NULL," ")))
-	{
-	  double c = atof(cline);
-	  double d = atof(strtok(NULL," "));
-	  IFEM::cout <<" c="<< c <<" d="<< d;
-	  if (!mySol)
-	    mySol = new NavierPlate(a,b,t,E,nu,pz,xi,eta,c,d);
-	}
-	else if (!mySol)
-	  mySol = new NavierPlate(a,b,t,E,nu,pz,xi,eta);
+        double c = atof(cline);
+        double d = atof(strtok(nullptr," "));
+        IFEM::cout <<" c="<< c <<" d="<< d;
+        if (!mySol)
+          mySol = new NavierPlate(a,b,t,E,nu,pz,xi,eta,c,d);
       }
       else if (!mySol)
-	mySol = new NavierPlate(a,b,t,E,nu,pz);
+        mySol = new NavierPlate(a,b,t,E,nu,pz,xi,eta);
     }
-    else if (!strncasecmp(cline,"EXPRESSION",10))
-    {
-      IFEM::cout <<"\nAnalytical solution: Expression"<< std::endl;
-      int lines = (cline = strtok(NULL," ")) ? atoi(cline) : 0;
-      if (!mySol)
-        mySol = new AnaSol(is,lines,false);
-    }
-    else
-    {
-      std::cerr <<"  ** SIMLinElKL::parse: Unknown analytical solution "
-                << cline <<" (ignored)"<< std::endl;
-      return true;
-    }
+    else if (!mySol)
+      mySol = new NavierPlate(a,b,t,E,nu,pz);
   }
-
+  else if (!strncasecmp(cline,"EXPRESSION",10))
+  {
+    IFEM::cout <<"\nAnalytical solution: Expression"<< std::endl;
+    int lines = (cline = strtok(nullptr," ")) ? atoi(cline) : 0;
+    if (!mySol)
+      mySol = new AnaSol(is,lines,false);
+  }
   else
-    return this->SIMKLShell::parse(keyWord,is);
+    std::cerr <<"  ** SIMLinElKL::parse: Unknown analytical solution "
+              << cline <<" (ignored)"<< std::endl;
 
   return true;
 }
 
 
-bool SIMLinElKL::parse (const TiXmlElement* elem)
+bool SIMLinElKL::parseAnaSol (const TiXmlElement* elem)
 {
-  if (strcasecmp(elem->Value(),"kirchhofflove"))
-    return this->SIM2D::parse(elem);
-  else if (!this->SIMKLShell::parse(elem))
-    return false;
-
-  const TiXmlElement* child = elem->FirstChildElement();
-  for (; child; child = child->NextSiblingElement())
-    if (!strcasecmp(child->Value(),"anasol"))
+  std::string type;
+  utl::getAttribute(elem,"type",type,true);
+  if (type == "navierplate")
+  {
+    double a = 0.0, b = 0.0, c = 0.0, d = 0.0, t = 0.0;
+    double E = 10000.0, nu = 0.3, pz = 1.0, xi = 0.0, eta = 0.0;
+    int max_mn = 100;
+    utl::getAttribute(elem,"a",a);
+    utl::getAttribute(elem,"b",b);
+    utl::getAttribute(elem,"c",c);
+    utl::getAttribute(elem,"d",d);
+    utl::getAttribute(elem,"t",t);
+    utl::getAttribute(elem,"E",E);
+    utl::getAttribute(elem,"nu",nu);
+    utl::getAttribute(elem,"pz",pz);
+    utl::getAttribute(elem,"xi",xi);
+    utl::getAttribute(elem,"eta",eta);
+    utl::getAttribute(elem,"nTerm",max_mn);
+    IFEM::cout <<"\tAnalytic solution: NavierPlate a="<< a <<" b="<< b
+               <<" t="<< t <<" E="<< E <<" nu="<< nu <<" pz="<< pz;
+    if (xi != 0.0 && eta != 0.0)
     {
-      std::string type;
-      utl::getAttribute(child,"type",type,true);
-      if (type == "navierplate") {
-        double a = 0.0, b = 0.0, c = 0.0, d = 0.0, t = 0.0;
-        double E = 10000.0, nu = 0.3, pz = 1.0, xi = 0.0, eta = 0.0;
-        int max_mn = 100;
-        utl::getAttribute(child,"a",a);
-        utl::getAttribute(child,"b",b);
-        utl::getAttribute(child,"c",c);
-        utl::getAttribute(child,"d",d);
-        utl::getAttribute(child,"t",t);
-        utl::getAttribute(child,"E",E);
-        utl::getAttribute(child,"nu",nu);
-        utl::getAttribute(child,"pz",pz);
-        utl::getAttribute(child,"xi",xi);
-        utl::getAttribute(child,"eta",eta);
-        utl::getAttribute(child,"nTerm",max_mn);
-        IFEM::cout <<"\tAnalytic solution: NavierPlate a="<< a <<" b="<< b
-                   <<" t="<< t <<" E="<< E <<" nu="<< nu <<" pz="<< pz;
-        if (xi != 0.0 && eta != 0.0) {
-          IFEM::cout <<" xi="<< xi <<" eta="<< eta;
-          if (c != 0.0 && d != 0.0) {
-            IFEM::cout <<" c="<< c <<" d="<< d;
-            if (!mySol)
-              mySol = new NavierPlate(a,b,t,E,nu,pz,xi,eta,c,d,max_mn);
-          }
-          else if (!mySol)
-            mySol = new NavierPlate(a,b,t,E,nu,pz,xi,eta,0.0,0.0,max_mn);
-        }
-        else if (!mySol)
-          mySol = new NavierPlate(a,b,t,E,nu,pz,max_mn);
-      }
-      else if (type == "circularplate") {
-        double R = 0.0, t = 0.0, E = 10000.0, nu = 0.3, P = 1000000.0;
-        utl::getAttribute(child,"R",R);
-        utl::getAttribute(child,"t",t);
-        utl::getAttribute(child,"E",E);
-        utl::getAttribute(child,"nu",nu);
-        utl::getAttribute(child,"P",P);
-        IFEM::cout <<"\tAnalytic solution: CircularPlate R="<< R <<" t="<< t
-                   <<" E="<< E <<" nu="<< nu <<" P="<< P << std::endl;
+      IFEM::cout <<" xi="<< xi <<" eta="<< eta;
+      if (c != 0.0 && d != 0.0)
+      {
+        IFEM::cout <<" c="<< c <<" d="<< d;
         if (!mySol)
-          mySol = new CircularPlate(R,t,E,nu,P);
+          mySol = new NavierPlate(a,b,t,E,nu,pz,xi,eta,c,d,max_mn);
       }
-      else if (type == "expression") {
-        IFEM::cout <<"\tAnalytical solution: Expression"<< std::endl;
-        if (!mySol)
-          mySol = new AnaSol(child);
-      }
-      else
-        std::cerr <<"  ** SIMLinElKL::parse: Unknown analytical solution "
-                  << type <<" (ignored)"<< std::endl;
+      else if (!mySol)
+        mySol = new NavierPlate(a,b,t,E,nu,pz,xi,eta,0.0,0.0,max_mn);
     }
+    else if (!mySol)
+      mySol = new NavierPlate(a,b,t,E,nu,pz,max_mn);
+  }
+  else if (type == "circularplate")
+  {
+    double R = 0.0, t = 0.0, E = 10000.0, nu = 0.3, P = 1000000.0;
+    utl::getAttribute(elem,"R",R);
+    utl::getAttribute(elem,"t",t);
+    utl::getAttribute(elem,"E",E);
+    utl::getAttribute(elem,"nu",nu);
+    utl::getAttribute(elem,"P",P);
+    IFEM::cout <<"\tAnalytic solution: CircularPlate R="<< R <<" t="<< t
+               <<" E="<< E <<" nu="<< nu <<" P="<< P << std::endl;
+    if (!mySol)
+      mySol = new CircularPlate(R,t,E,nu,P);
+  }
+  else if (type == "expression")
+  {
+    IFEM::cout <<"\tAnalytical solution: Expression"<< std::endl;
+    if (!mySol)
+      mySol = new AnaSol(elem);
+  }
+  else
+    std::cerr <<"  ** SIMLinElKL::parse: Unknown analytical solution "
+              << type <<" (ignored)"<< std::endl;
 
   return true;
 }

--- a/Linear/SIMLinElKL.h
+++ b/Linear/SIMLinElKL.h
@@ -36,13 +36,13 @@ protected:
   //! \brief Returns the actual integrand.
   virtual KirchhoffLove* getProblem(int version = 1);
 
-  //! \brief Parses a data section from the input stream.
+  //! \brief Parses the analytical solution from an input stream.
   //! \param[in] keyWord Keyword of current data section to read
   //! \param is The file stream to read from
-  virtual bool parse(char* keyWord, std::istream& is);
-  //! \brief Parses a data section from an XML element.
+  virtual bool parseAnaSol(char* keyWord, std::istream& is);
+  //! \brief Parses the analytical solution from an XML element.
   //! \param[in] elem The XML element to parse
-  virtual bool parse(const TiXmlElement* elem);
+  virtual bool parseAnaSol(const TiXmlElement* elem);
 
   //! \brief Performs some pre-processing tasks on the FE model.
   virtual void preprocessA();

--- a/Shell/SIMKLShell.C
+++ b/Shell/SIMKLShell.C
@@ -177,6 +177,9 @@ bool SIMKLShell::parse (char* keyWord, std::istream& is)
     }
   }
 
+  else if (!strncasecmp(keyWord,"ANASOL",6))
+    return this->parseAnaSol(keyWord,is);
+
   else
     return this->SIM2D::parse(keyWord,is);
 
@@ -312,6 +315,9 @@ bool SIMKLShell::parse (const TiXmlElement* elem)
           klp->setPressure(myScalars[code]);
       }
     }
+
+    else if (!strcasecmp(child->Value(),"anasol"))
+      ok = this->parseAnaSol(child);
 
     else if (!klp->parse(child))
       ok = this->SIM2D::parse(child);


### PR DESCRIPTION
For reduced code duplication. A new virtual method parseAnaSol is now the entry point for parsing the "anasol" tag. This method is Dim-independent (no template specialization). Only dimension-dependent hard-coded analytical solutions remain in the parseDimSpecific methods, which no longer are virtual.