### PR TITLE
Fixed: Output to hdf5 for adaptive and non-adaptive simulation

### DIFF
--- a/Linear/CMakeLists.txt
+++ b/Linear/CMakeLists.txt
@@ -61,13 +61,15 @@ file(GLOB LINEL_TESTFILES RELATIVE ${PROJECT_SOURCE_DIR}/Test
                                    ${PROJECT_SOURCE_DIR}/Test/*.reg)
 file(GLOB LINEL_VTF_FILES RELATIVE ${PROJECT_SOURCE_DIR}/Test
                                    ${PROJECT_SOURCE_DIR}/Test/*.vreg)
-file(GLOB LINEL_HDF5_FILES RELATIVE ${PROJECT_SOURCE_DIR}/Test
+file(GLOB LINEL_HDF5FILES RELATIVE ${PROJECT_SOURCE_DIR}/Test
                                    ${PROJECT_SOURCE_DIR}/Test/*.hreg)
 if(LRSpline_FOUND OR LRSPLINE_FOUND)
   file(GLOB LRE_TESTFILES RELATIVE ${PROJECT_SOURCE_DIR}/Test
                                    ${PROJECT_SOURCE_DIR}/Test/LR/*.reg)
   file(GLOB LRE_VTF_FILES RELATIVE ${PROJECT_SOURCE_DIR}/Test
                                    ${PROJECT_SOURCE_DIR}/Test/LR/*.vreg)
+  file(GLOB LRE_HDF5FILES RELATIVE ${PROJECT_SOURCE_DIR}/Test
+                                   ${PROJECT_SOURCE_DIR}/Test/LR/*.hreg)
 endif()
 list(REMOVE_ITEM LINEL_TESTFILES CanTS2D-p2-restart.reg)
 
@@ -79,11 +81,11 @@ if(NOT MPI_FOUND OR IFEM_SERIAL_TESTS_IN_PARALLEL)
   foreach(TESTFILE ${LINEL_TESTFILES} ${LRE_TESTFILES})
     ifem_add_test(${TESTFILE} LinEl)
   endforeach()
-  foreach(VTFFILE ${LINEL_VTF_FILES} ${LRE_VTF_FILES})
-    ifem_add_vtf_test(${VTFFILE} LinEl)
+  foreach(TESTFILE ${LINEL_VTF_FILES} ${LRE_VTF_FILES})
+    ifem_add_vtf_test(${TESTFILE} LinEl)
   endforeach()
-  foreach(HDF5FILE ${LINEL_HDF5_FILES})
-    ifem_add_hdf5_test(${HDF5FILE} LinEl)
+  foreach(TESTFILE ${LINEL_HDF5FILES} ${LRE_HDF5FILES})
+    ifem_add_hdf5_test(${TESTFILE} LinEl)
   endforeach()
 endif()
 

--- a/Linear/Test/LR/Lshape-adap-p2.hreg
+++ b/Linear/Test/LR/Lshape-adap-p2.hreg
@@ -1,0 +1,473 @@
+Lshape-adap-p2.xinp -2Dpstrain -adap
+
+/                        Group
+/0                       Group
+/0/Elasticity-1          Group
+/0/Elasticity-1/basis    Group
+/0/Elasticity-1/basis/1  Dataset {6341}
+/0/Elasticity-1/fields   Group
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ P1 Group
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ P1/1 Dataset {66}
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ P2 Group
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ P2/1 Dataset {66}
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xx Group
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xx/1 Dataset {66}
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xy Group
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xy/1 Dataset {66}
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_yy Group
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_yy/1 Dataset {66}
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_zz Group
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_zz/1 Dataset {66}
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ von\ Mises\ stress Group
+/0/Elasticity-1/fields/Continuous\ global\ L2-projection\ von\ Mises\ stress/1 Dataset {66}
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ P1 Group
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ P1/1 Dataset {66}
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ P2 Group
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ P2/1 Dataset {66}
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xx Group
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xx/1 Dataset {66}
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xy Group
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xy/1 Dataset {66}
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_yy Group
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_yy/1 Dataset {66}
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_zz Group
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_zz/1 Dataset {66}
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ von\ Mises\ stress Group
+/0/Elasticity-1/fields/Discrete\ global\ L2-projection\ von\ Mises\ stress/1 Dataset {66}
+/0/Elasticity-1/fields/Greville\ point\ projection\ P1 Group
+/0/Elasticity-1/fields/Greville\ point\ projection\ P1/1 Dataset {66}
+/0/Elasticity-1/fields/Greville\ point\ projection\ P2 Group
+/0/Elasticity-1/fields/Greville\ point\ projection\ P2/1 Dataset {66}
+/0/Elasticity-1/fields/Greville\ point\ projection\ s_xx Group
+/0/Elasticity-1/fields/Greville\ point\ projection\ s_xx/1 Dataset {66}
+/0/Elasticity-1/fields/Greville\ point\ projection\ s_xy Group
+/0/Elasticity-1/fields/Greville\ point\ projection\ s_xy/1 Dataset {66}
+/0/Elasticity-1/fields/Greville\ point\ projection\ s_yy Group
+/0/Elasticity-1/fields/Greville\ point\ projection\ s_yy/1 Dataset {66}
+/0/Elasticity-1/fields/Greville\ point\ projection\ s_zz Group
+/0/Elasticity-1/fields/Greville\ point\ projection\ s_zz/1 Dataset {66}
+/0/Elasticity-1/fields/Greville\ point\ projection\ von\ Mises\ stress Group
+/0/Elasticity-1/fields/Greville\ point\ projection\ von\ Mises\ stress/1 Dataset {66}
+/0/Elasticity-1/fields/displacement Group
+/0/Elasticity-1/fields/displacement/1 Dataset {132}
+/0/Elasticity-1/knotspan Group
+/0/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/0/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {32}
+/0/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (u^r,u^r)^0.5 Group
+/0/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (u^r,u^r)^0.5/1 Dataset {32}
+/0/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r Group
+/0/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {32}
+/0/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/0/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {32}
+/0/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(u^r,u^r)^0.5 Group
+/0/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(u^r,u^r)^0.5/1 Dataset {32}
+/0/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index Group
+/0/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index/1 Dataset {32}
+/0/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/0/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {32}
+/0/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (u^r,u^r)^0.5 Group
+/0/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (u^r,u^r)^0.5/1 Dataset {32}
+/0/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r Group
+/0/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {32}
+/0/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/0/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {32}
+/0/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(u^r,u^r)^0.5 Group
+/0/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(u^r,u^r)^0.5/1 Dataset {32}
+/0/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ effectivity\ index Group
+/0/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ effectivity\ index/1 Dataset {32}
+/0/Elasticity-1/knotspan/Greville\ point\ projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/0/Elasticity-1/knotspan/Greville\ point\ projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {32}
+/0/Elasticity-1/knotspan/Greville\ point\ projection\ (u^r,u^r)^0.5 Group
+/0/Elasticity-1/knotspan/Greville\ point\ projection\ (u^r,u^r)^0.5/1 Dataset {32}
+/0/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u-u^r Group
+/0/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {32}
+/0/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/0/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {32}
+/0/Elasticity-1/knotspan/Greville\ point\ projection\ a(u^r,u^r)^0.5 Group
+/0/Elasticity-1/knotspan/Greville\ point\ projection\ a(u^r,u^r)^0.5/1 Dataset {32}
+/0/Elasticity-1/knotspan/Greville\ point\ projection\ effectivity\ index Group
+/0/Elasticity-1/knotspan/Greville\ point\ projection\ effectivity\ index/1 Dataset {32}
+/0/Elasticity-1/knotspan/a(e,e)^0.5,\ e=u-u^h Group
+/0/Elasticity-1/knotspan/a(e,e)^0.5,\ e=u-u^h/1 Dataset {32}
+/0/Elasticity-1/knotspan/a(u,u)^0.5 Group
+/0/Elasticity-1/knotspan/a(u,u)^0.5/1 Dataset {32}
+/0/Elasticity-1/knotspan/a(u^h,u^h)^0.5 Group
+/0/Elasticity-1/knotspan/a(u^h,u^h)^0.5/1 Dataset {32}
+/0/Elasticity-1/knotspan/volume Group
+/0/Elasticity-1/knotspan/volume/1 Dataset {32}
+/1                       Group
+/1/Elasticity-1          Group
+/1/Elasticity-1/basis    Group
+/1/Elasticity-1/basis/1  Dataset {15128}
+/1/Elasticity-1/fields   Group
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ P1 Group
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ P1/1 Dataset {117}
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ P2 Group
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ P2/1 Dataset {117}
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xx Group
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xx/1 Dataset {117}
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xy Group
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xy/1 Dataset {117}
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_yy Group
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_yy/1 Dataset {117}
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_zz Group
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_zz/1 Dataset {117}
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ von\ Mises\ stress Group
+/1/Elasticity-1/fields/Continuous\ global\ L2-projection\ von\ Mises\ stress/1 Dataset {117}
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ P1 Group
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ P1/1 Dataset {117}
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ P2 Group
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ P2/1 Dataset {117}
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xx Group
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xx/1 Dataset {117}
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xy Group
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xy/1 Dataset {117}
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_yy Group
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_yy/1 Dataset {117}
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_zz Group
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_zz/1 Dataset {117}
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ von\ Mises\ stress Group
+/1/Elasticity-1/fields/Discrete\ global\ L2-projection\ von\ Mises\ stress/1 Dataset {117}
+/1/Elasticity-1/fields/Greville\ point\ projection\ P1 Group
+/1/Elasticity-1/fields/Greville\ point\ projection\ P1/1 Dataset {117}
+/1/Elasticity-1/fields/Greville\ point\ projection\ P2 Group
+/1/Elasticity-1/fields/Greville\ point\ projection\ P2/1 Dataset {117}
+/1/Elasticity-1/fields/Greville\ point\ projection\ s_xx Group
+/1/Elasticity-1/fields/Greville\ point\ projection\ s_xx/1 Dataset {117}
+/1/Elasticity-1/fields/Greville\ point\ projection\ s_xy Group
+/1/Elasticity-1/fields/Greville\ point\ projection\ s_xy/1 Dataset {117}
+/1/Elasticity-1/fields/Greville\ point\ projection\ s_yy Group
+/1/Elasticity-1/fields/Greville\ point\ projection\ s_yy/1 Dataset {117}
+/1/Elasticity-1/fields/Greville\ point\ projection\ s_zz Group
+/1/Elasticity-1/fields/Greville\ point\ projection\ s_zz/1 Dataset {117}
+/1/Elasticity-1/fields/Greville\ point\ projection\ von\ Mises\ stress Group
+/1/Elasticity-1/fields/Greville\ point\ projection\ von\ Mises\ stress/1 Dataset {117}
+/1/Elasticity-1/fields/displacement Group
+/1/Elasticity-1/fields/displacement/1 Dataset {234}
+/1/Elasticity-1/knotspan Group
+/1/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/1/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {86}
+/1/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (u^r,u^r)^0.5 Group
+/1/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (u^r,u^r)^0.5/1 Dataset {86}
+/1/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r Group
+/1/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {86}
+/1/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/1/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {86}
+/1/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(u^r,u^r)^0.5 Group
+/1/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(u^r,u^r)^0.5/1 Dataset {86}
+/1/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index Group
+/1/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index/1 Dataset {86}
+/1/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/1/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {86}
+/1/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (u^r,u^r)^0.5 Group
+/1/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (u^r,u^r)^0.5/1 Dataset {86}
+/1/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r Group
+/1/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {86}
+/1/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/1/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {86}
+/1/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(u^r,u^r)^0.5 Group
+/1/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(u^r,u^r)^0.5/1 Dataset {86}
+/1/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ effectivity\ index Group
+/1/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ effectivity\ index/1 Dataset {86}
+/1/Elasticity-1/knotspan/Greville\ point\ projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/1/Elasticity-1/knotspan/Greville\ point\ projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {86}
+/1/Elasticity-1/knotspan/Greville\ point\ projection\ (u^r,u^r)^0.5 Group
+/1/Elasticity-1/knotspan/Greville\ point\ projection\ (u^r,u^r)^0.5/1 Dataset {86}
+/1/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u-u^r Group
+/1/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {86}
+/1/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/1/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {86}
+/1/Elasticity-1/knotspan/Greville\ point\ projection\ a(u^r,u^r)^0.5 Group
+/1/Elasticity-1/knotspan/Greville\ point\ projection\ a(u^r,u^r)^0.5/1 Dataset {86}
+/1/Elasticity-1/knotspan/Greville\ point\ projection\ effectivity\ index Group
+/1/Elasticity-1/knotspan/Greville\ point\ projection\ effectivity\ index/1 Dataset {86}
+/1/Elasticity-1/knotspan/a(e,e)^0.5,\ e=u-u^h Group
+/1/Elasticity-1/knotspan/a(e,e)^0.5,\ e=u-u^h/1 Dataset {86}
+/1/Elasticity-1/knotspan/a(u,u)^0.5 Group
+/1/Elasticity-1/knotspan/a(u,u)^0.5/1 Dataset {86}
+/1/Elasticity-1/knotspan/a(u^h,u^h)^0.5 Group
+/1/Elasticity-1/knotspan/a(u^h,u^h)^0.5/1 Dataset {86}
+/1/Elasticity-1/knotspan/volume Group
+/1/Elasticity-1/knotspan/volume/1 Dataset {86}
+/2                       Group
+/2/Elasticity-1          Group
+/2/Elasticity-1/basis    Group
+/2/Elasticity-1/basis/1  Dataset {25024}
+/2/Elasticity-1/fields   Group
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ P1 Group
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ P1/1 Dataset {168}
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ P2 Group
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ P2/1 Dataset {168}
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xx Group
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xx/1 Dataset {168}
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xy Group
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xy/1 Dataset {168}
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_yy Group
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_yy/1 Dataset {168}
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_zz Group
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_zz/1 Dataset {168}
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ von\ Mises\ stress Group
+/2/Elasticity-1/fields/Continuous\ global\ L2-projection\ von\ Mises\ stress/1 Dataset {168}
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ P1 Group
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ P1/1 Dataset {168}
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ P2 Group
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ P2/1 Dataset {168}
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xx Group
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xx/1 Dataset {168}
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xy Group
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xy/1 Dataset {168}
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_yy Group
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_yy/1 Dataset {168}
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_zz Group
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_zz/1 Dataset {168}
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ von\ Mises\ stress Group
+/2/Elasticity-1/fields/Discrete\ global\ L2-projection\ von\ Mises\ stress/1 Dataset {168}
+/2/Elasticity-1/fields/Greville\ point\ projection\ P1 Group
+/2/Elasticity-1/fields/Greville\ point\ projection\ P1/1 Dataset {168}
+/2/Elasticity-1/fields/Greville\ point\ projection\ P2 Group
+/2/Elasticity-1/fields/Greville\ point\ projection\ P2/1 Dataset {168}
+/2/Elasticity-1/fields/Greville\ point\ projection\ s_xx Group
+/2/Elasticity-1/fields/Greville\ point\ projection\ s_xx/1 Dataset {168}
+/2/Elasticity-1/fields/Greville\ point\ projection\ s_xy Group
+/2/Elasticity-1/fields/Greville\ point\ projection\ s_xy/1 Dataset {168}
+/2/Elasticity-1/fields/Greville\ point\ projection\ s_yy Group
+/2/Elasticity-1/fields/Greville\ point\ projection\ s_yy/1 Dataset {168}
+/2/Elasticity-1/fields/Greville\ point\ projection\ s_zz Group
+/2/Elasticity-1/fields/Greville\ point\ projection\ s_zz/1 Dataset {168}
+/2/Elasticity-1/fields/Greville\ point\ projection\ von\ Mises\ stress Group
+/2/Elasticity-1/fields/Greville\ point\ projection\ von\ Mises\ stress/1 Dataset {168}
+/2/Elasticity-1/fields/displacement Group
+/2/Elasticity-1/fields/displacement/1 Dataset {336}
+/2/Elasticity-1/knotspan Group
+/2/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/2/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {140}
+/2/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (u^r,u^r)^0.5 Group
+/2/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (u^r,u^r)^0.5/1 Dataset {140}
+/2/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r Group
+/2/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {140}
+/2/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/2/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {140}
+/2/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(u^r,u^r)^0.5 Group
+/2/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(u^r,u^r)^0.5/1 Dataset {140}
+/2/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index Group
+/2/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index/1 Dataset {140}
+/2/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/2/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {140}
+/2/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (u^r,u^r)^0.5 Group
+/2/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (u^r,u^r)^0.5/1 Dataset {140}
+/2/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r Group
+/2/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {140}
+/2/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/2/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {140}
+/2/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(u^r,u^r)^0.5 Group
+/2/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(u^r,u^r)^0.5/1 Dataset {140}
+/2/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ effectivity\ index Group
+/2/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ effectivity\ index/1 Dataset {140}
+/2/Elasticity-1/knotspan/Greville\ point\ projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/2/Elasticity-1/knotspan/Greville\ point\ projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {140}
+/2/Elasticity-1/knotspan/Greville\ point\ projection\ (u^r,u^r)^0.5 Group
+/2/Elasticity-1/knotspan/Greville\ point\ projection\ (u^r,u^r)^0.5/1 Dataset {140}
+/2/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u-u^r Group
+/2/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {140}
+/2/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/2/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {140}
+/2/Elasticity-1/knotspan/Greville\ point\ projection\ a(u^r,u^r)^0.5 Group
+/2/Elasticity-1/knotspan/Greville\ point\ projection\ a(u^r,u^r)^0.5/1 Dataset {140}
+/2/Elasticity-1/knotspan/Greville\ point\ projection\ effectivity\ index Group
+/2/Elasticity-1/knotspan/Greville\ point\ projection\ effectivity\ index/1 Dataset {140}
+/2/Elasticity-1/knotspan/a(e,e)^0.5,\ e=u-u^h Group
+/2/Elasticity-1/knotspan/a(e,e)^0.5,\ e=u-u^h/1 Dataset {140}
+/2/Elasticity-1/knotspan/a(u,u)^0.5 Group
+/2/Elasticity-1/knotspan/a(u,u)^0.5/1 Dataset {140}
+/2/Elasticity-1/knotspan/a(u^h,u^h)^0.5 Group
+/2/Elasticity-1/knotspan/a(u^h,u^h)^0.5/1 Dataset {140}
+/2/Elasticity-1/knotspan/volume Group
+/2/Elasticity-1/knotspan/volume/1 Dataset {140}
+/3                       Group
+/3/Elasticity-1          Group
+/3/Elasticity-1/basis    Group
+/3/Elasticity-1/basis/1  Dataset {35655}
+/3/Elasticity-1/fields   Group
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ P1 Group
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ P1/1 Dataset {219}
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ P2 Group
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ P2/1 Dataset {219}
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xx Group
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xx/1 Dataset {219}
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xy Group
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xy/1 Dataset {219}
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_yy Group
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_yy/1 Dataset {219}
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_zz Group
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_zz/1 Dataset {219}
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ von\ Mises\ stress Group
+/3/Elasticity-1/fields/Continuous\ global\ L2-projection\ von\ Mises\ stress/1 Dataset {219}
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ P1 Group
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ P1/1 Dataset {219}
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ P2 Group
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ P2/1 Dataset {219}
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xx Group
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xx/1 Dataset {219}
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xy Group
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xy/1 Dataset {219}
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_yy Group
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_yy/1 Dataset {219}
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_zz Group
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_zz/1 Dataset {219}
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ von\ Mises\ stress Group
+/3/Elasticity-1/fields/Discrete\ global\ L2-projection\ von\ Mises\ stress/1 Dataset {219}
+/3/Elasticity-1/fields/Greville\ point\ projection\ P1 Group
+/3/Elasticity-1/fields/Greville\ point\ projection\ P1/1 Dataset {219}
+/3/Elasticity-1/fields/Greville\ point\ projection\ P2 Group
+/3/Elasticity-1/fields/Greville\ point\ projection\ P2/1 Dataset {219}
+/3/Elasticity-1/fields/Greville\ point\ projection\ s_xx Group
+/3/Elasticity-1/fields/Greville\ point\ projection\ s_xx/1 Dataset {219}
+/3/Elasticity-1/fields/Greville\ point\ projection\ s_xy Group
+/3/Elasticity-1/fields/Greville\ point\ projection\ s_xy/1 Dataset {219}
+/3/Elasticity-1/fields/Greville\ point\ projection\ s_yy Group
+/3/Elasticity-1/fields/Greville\ point\ projection\ s_yy/1 Dataset {219}
+/3/Elasticity-1/fields/Greville\ point\ projection\ s_zz Group
+/3/Elasticity-1/fields/Greville\ point\ projection\ s_zz/1 Dataset {219}
+/3/Elasticity-1/fields/Greville\ point\ projection\ von\ Mises\ stress Group
+/3/Elasticity-1/fields/Greville\ point\ projection\ von\ Mises\ stress/1 Dataset {219}
+/3/Elasticity-1/fields/displacement Group
+/3/Elasticity-1/fields/displacement/1 Dataset {438}
+/3/Elasticity-1/knotspan Group
+/3/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/3/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {194}
+/3/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (u^r,u^r)^0.5 Group
+/3/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (u^r,u^r)^0.5/1 Dataset {194}
+/3/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r Group
+/3/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {194}
+/3/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/3/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {194}
+/3/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(u^r,u^r)^0.5 Group
+/3/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(u^r,u^r)^0.5/1 Dataset {194}
+/3/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index Group
+/3/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index/1 Dataset {194}
+/3/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/3/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {194}
+/3/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (u^r,u^r)^0.5 Group
+/3/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (u^r,u^r)^0.5/1 Dataset {194}
+/3/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r Group
+/3/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {194}
+/3/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/3/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {194}
+/3/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(u^r,u^r)^0.5 Group
+/3/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(u^r,u^r)^0.5/1 Dataset {194}
+/3/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ effectivity\ index Group
+/3/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ effectivity\ index/1 Dataset {194}
+/3/Elasticity-1/knotspan/Greville\ point\ projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/3/Elasticity-1/knotspan/Greville\ point\ projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {194}
+/3/Elasticity-1/knotspan/Greville\ point\ projection\ (u^r,u^r)^0.5 Group
+/3/Elasticity-1/knotspan/Greville\ point\ projection\ (u^r,u^r)^0.5/1 Dataset {194}
+/3/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u-u^r Group
+/3/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {194}
+/3/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/3/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {194}
+/3/Elasticity-1/knotspan/Greville\ point\ projection\ a(u^r,u^r)^0.5 Group
+/3/Elasticity-1/knotspan/Greville\ point\ projection\ a(u^r,u^r)^0.5/1 Dataset {194}
+/3/Elasticity-1/knotspan/Greville\ point\ projection\ effectivity\ index Group
+/3/Elasticity-1/knotspan/Greville\ point\ projection\ effectivity\ index/1 Dataset {194}
+/3/Elasticity-1/knotspan/a(e,e)^0.5,\ e=u-u^h Group
+/3/Elasticity-1/knotspan/a(e,e)^0.5,\ e=u-u^h/1 Dataset {194}
+/3/Elasticity-1/knotspan/a(u,u)^0.5 Group
+/3/Elasticity-1/knotspan/a(u,u)^0.5/1 Dataset {194}
+/3/Elasticity-1/knotspan/a(u^h,u^h)^0.5 Group
+/3/Elasticity-1/knotspan/a(u^h,u^h)^0.5/1 Dataset {194}
+/3/Elasticity-1/knotspan/volume Group
+/3/Elasticity-1/knotspan/volume/1 Dataset {194}
+/4                       Group
+/4/Elasticity-1          Group
+/4/Elasticity-1/basis    Group
+/4/Elasticity-1/basis/1  Dataset {54793}
+/4/Elasticity-1/fields   Group
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ P1 Group
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ P1/1 Dataset {329}
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ P2 Group
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ P2/1 Dataset {329}
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xx Group
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xx/1 Dataset {329}
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xy Group
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_xy/1 Dataset {329}
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_yy Group
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_yy/1 Dataset {329}
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_zz Group
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ s_zz/1 Dataset {329}
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ von\ Mises\ stress Group
+/4/Elasticity-1/fields/Continuous\ global\ L2-projection\ von\ Mises\ stress/1 Dataset {329}
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ P1 Group
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ P1/1 Dataset {329}
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ P2 Group
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ P2/1 Dataset {329}
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xx Group
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xx/1 Dataset {329}
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xy Group
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_xy/1 Dataset {329}
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_yy Group
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_yy/1 Dataset {329}
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_zz Group
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ s_zz/1 Dataset {329}
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ von\ Mises\ stress Group
+/4/Elasticity-1/fields/Discrete\ global\ L2-projection\ von\ Mises\ stress/1 Dataset {329}
+/4/Elasticity-1/fields/Greville\ point\ projection\ P1 Group
+/4/Elasticity-1/fields/Greville\ point\ projection\ P1/1 Dataset {329}
+/4/Elasticity-1/fields/Greville\ point\ projection\ P2 Group
+/4/Elasticity-1/fields/Greville\ point\ projection\ P2/1 Dataset {329}
+/4/Elasticity-1/fields/Greville\ point\ projection\ s_xx Group
+/4/Elasticity-1/fields/Greville\ point\ projection\ s_xx/1 Dataset {329}
+/4/Elasticity-1/fields/Greville\ point\ projection\ s_xy Group
+/4/Elasticity-1/fields/Greville\ point\ projection\ s_xy/1 Dataset {329}
+/4/Elasticity-1/fields/Greville\ point\ projection\ s_yy Group
+/4/Elasticity-1/fields/Greville\ point\ projection\ s_yy/1 Dataset {329}
+/4/Elasticity-1/fields/Greville\ point\ projection\ s_zz Group
+/4/Elasticity-1/fields/Greville\ point\ projection\ s_zz/1 Dataset {329}
+/4/Elasticity-1/fields/Greville\ point\ projection\ von\ Mises\ stress Group
+/4/Elasticity-1/fields/Greville\ point\ projection\ von\ Mises\ stress/1 Dataset {329}
+/4/Elasticity-1/fields/displacement Group
+/4/Elasticity-1/fields/displacement/1 Dataset {658}
+/4/Elasticity-1/knotspan Group
+/4/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/4/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {284}
+/4/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (u^r,u^r)^0.5 Group
+/4/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ (u^r,u^r)^0.5/1 Dataset {284}
+/4/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r Group
+/4/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {284}
+/4/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/4/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {284}
+/4/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(u^r,u^r)^0.5 Group
+/4/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ a(u^r,u^r)^0.5/1 Dataset {284}
+/4/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index Group
+/4/Elasticity-1/knotspan/Continuous\ global\ L2-projection\ effectivity\ index/1 Dataset {284}
+/4/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/4/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {284}
+/4/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (u^r,u^r)^0.5 Group
+/4/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ (u^r,u^r)^0.5/1 Dataset {284}
+/4/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r Group
+/4/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {284}
+/4/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/4/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {284}
+/4/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(u^r,u^r)^0.5 Group
+/4/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ a(u^r,u^r)^0.5/1 Dataset {284}
+/4/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ effectivity\ index Group
+/4/Elasticity-1/knotspan/Discrete\ global\ L2-projection\ effectivity\ index/1 Dataset {284}
+/4/Elasticity-1/knotspan/Greville\ point\ projection\ (e,e)^0.5,\ e=u^r-u^h Group
+/4/Elasticity-1/knotspan/Greville\ point\ projection\ (e,e)^0.5,\ e=u^r-u^h/1 Dataset {284}
+/4/Elasticity-1/knotspan/Greville\ point\ projection\ (u^r,u^r)^0.5 Group
+/4/Elasticity-1/knotspan/Greville\ point\ projection\ (u^r,u^r)^0.5/1 Dataset {284}
+/4/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u-u^r Group
+/4/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u-u^r/1 Dataset {284}
+/4/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u^r-u^h Group
+/4/Elasticity-1/knotspan/Greville\ point\ projection\ a(e,e)^0.5,\ e=u^r-u^h/1 Dataset {284}
+/4/Elasticity-1/knotspan/Greville\ point\ projection\ a(u^r,u^r)^0.5 Group
+/4/Elasticity-1/knotspan/Greville\ point\ projection\ a(u^r,u^r)^0.5/1 Dataset {284}
+/4/Elasticity-1/knotspan/Greville\ point\ projection\ effectivity\ index Group
+/4/Elasticity-1/knotspan/Greville\ point\ projection\ effectivity\ index/1 Dataset {284}
+/4/Elasticity-1/knotspan/a(e,e)^0.5,\ e=u-u^h Group
+/4/Elasticity-1/knotspan/a(e,e)^0.5,\ e=u-u^h/1 Dataset {284}
+/4/Elasticity-1/knotspan/a(u,u)^0.5 Group
+/4/Elasticity-1/knotspan/a(u,u)^0.5/1 Dataset {284}
+/4/Elasticity-1/knotspan/a(u^h,u^h)^0.5 Group
+/4/Elasticity-1/knotspan/a(u^h,u^h)^0.5/1 Dataset {284}
+/4/Elasticity-1/knotspan/volume Group
+/4/Elasticity-1/knotspan/volume/1 Dataset {284}


### PR DESCRIPTION
This should do it, the projections and norms are now correctly written to HDF5 in both cases, I think.
This was broken after #85 with de543470924c2527a394a4bb87ed94e94d92a2ba, probably as a result of this being a much older commit that had been faulty merged with more recent changes, like d64891a8dc371623972a1a6af5986892e7e4ea25 from #50.

OPM/IFEM#413 is then probably not necessary.