### PR TITLE
fix constructor for FractureDynamics usage

### DIFF
--- a/SIMElasticityWrap.C
+++ b/SIMElasticityWrap.C
@@ -22,7 +22,7 @@
 
 
 template<class Dim>
-SIMElasticityWrap<Dim>::SIMElasticityWrap ()
+SIMElasticityWrap<Dim>::SIMElasticityWrap (const std::vector<unsigned char>&)
 {
   Dim::msgLevel = 1;
   Dim::myHeading = "Elasticity solver";

--- a/SIMElasticityWrap.h
+++ b/SIMElasticityWrap.h
@@ -34,7 +34,7 @@ class SIMElasticityWrap : public SIMElasticity<Dim>, public SIMsolution
 {
 protected:
   //! \brief The default constructor is protected as this is an interface class.
-  SIMElasticityWrap();
+  explicit SIMElasticityWrap(const std::vector<unsigned char>& = {});
 
 public:
   //! \brief Empty destructor.


### PR DESCRIPTION
There's a constructor in SimDynElasticitiy passing fields. Since we now explicitly instance the template, this constructor is instanced for SIMElasticityWrap so we need a param.