### PR TITLE
Added: strain-tag inside the postprocessing context for strain output

### DIFF
--- a/SIMElasticity.h
+++ b/SIMElasticity.h
@@ -492,9 +492,11 @@ protected:
     if (!strcasecmp(elem->Value(),"postprocessing"))
     {
       const TiXmlElement* child = elem->FirstChildElement();
-      for (; child && !plotRgd; child = child->NextSiblingElement())
+      for (; child; child = child->NextSiblingElement())
         if (!strcasecmp(child->Value(),"plot_rigid"))
           plotRgd = true;
+        else if (!strcasecmp(child->Value(),"strain"))
+          Elasticity::wantStrain = true;
     }
 
     if (strcasecmp(elem->Value(),myContext.c_str()))


### PR DESCRIPTION
Affects output to VTF and HDF5 as well as result point printout, no influence on the calculations themselves.