### PR TITLE
Fix clang crash

### DIFF
--- a/LinearElasticity.h
+++ b/LinearElasticity.h
@@ -94,6 +94,7 @@ public:
   virtual bool evalInt(LocalIntegral& elmInt, const FiniteElement& fe,
                        const Vec3& X, const Vec3& normal) const;
 
+  using Elasticity::finalizeElement;
   //! \brief Finalizes the element quantities after the numerical integration.
   //! \param elmInt The local integral object to receive the contributions
   //! \param[in] fe Nodal and integration point data for current element

--- a/SIMElasticity.h
+++ b/SIMElasticity.h
@@ -21,7 +21,7 @@
 class Elasticity;
 class Material;
 class TimeStep;
-class TimeDomain;
+struct TimeDomain;
 
 typedef std::vector<Material*> MaterialVec; //!< Convenience declaration
 


### PR DESCRIPTION
Fixes crash when built with clang 15 (wrong overload is called for finalizeElement).

Also fix a warning while at it.