### PR TITLE
Extension of ElasticBase interface class

### DIFF
--- a/Beam/ElasticBar.C
+++ b/Beam/ElasticBar.C
@@ -22,6 +22,7 @@ ElasticBar::ElasticBar (char strm, unsigned short int nd, unsigned short int ns)
 {
   strain_meassure = strm;
 
+  nsd = nd; // Number of spatial dimenstions
   npv = nd; // Number of primary unknowns per node
   nSV = ns; // Number of solution vectors in core
 

--- a/Beam/ElasticBeam.C
+++ b/Beam/ElasticBeam.C
@@ -77,6 +77,7 @@ template<> HHTBeamMats::BeamMats (double a1, double a2, double b, double)
 
 ElasticBeam::ElasticBeam (unsigned short int n) : inLocalAxes(true)
 {
+  nsd = 3; // Number of spatial dimenstions
   npv = 6; // Number of primary unknowns per node
   nSV = n; // Number of solution vectors in core
 

--- a/Beam/SIMElasticBar.C
+++ b/Beam/SIMElasticBar.C
@@ -163,20 +163,7 @@ bool SIMElasticBar::parse (const tinyxml2::XMLElement* elem)
   for (; child && ok; child = child->NextSiblingElement())
   {
     IFEM::cout <<"  Parsing <"<< child->Value() <<">"<< std::endl;
-    if (!strcasecmp(child->Value(),"gravity"))
-    {
-      Vec3 g;
-      utl::getAttribute(child,"x",g.x);
-      utl::getAttribute(child,"y",g.y);
-      utl::getAttribute(child,"z",g.z);
-      IFEM::cout <<"\tGravitation vector: "<< g << std::endl;
-      if (bar)
-        bar->setGravity(g);
-      else
-        beam->setGravity(g);
-    }
-
-    else if (!strcasecmp(child->Value(),"material"))
+    if (!strcasecmp(child->Value(),"material"))
     {
       double E = 2.1e11, rho = 7.85e3;
       utl::getAttribute(child,"E",E);

--- a/ElasticBase.C
+++ b/ElasticBase.C
@@ -15,7 +15,10 @@
 #include "FiniteElement.h"
 #include "ElmMats.h"
 #include "TimeDomain.h"
+#include "Utilities.h"
 #include "BDF.h"
+#include "IFEM.h"
+#include "tinyxml2.h"
 
 
 ElasticBase::ElasticBase () : IntegrandBase(0)
@@ -34,6 +37,31 @@ ElasticBase::ElasticBase () : IntegrandBase(0)
 ElasticBase::~ElasticBase ()
 {
   delete bdf;
+}
+
+
+bool ElasticBase::parse (const tinyxml2::XMLElement* elem)
+{
+  if (!strcasecmp(elem->Value(),"gravity") && nsd > 0)
+  {
+    utl::getAttribute(elem,"x",gravity.x);
+    IFEM::cout <<"\tGravitation vector: "<< gravity.x;
+    if (nsd >= 2)
+    {
+      utl::getAttribute(elem,"y",gravity.y);
+      IFEM::cout <<" "<< gravity.y;
+    }
+    if (nsd >= 3)
+    {
+      utl::getAttribute(elem,"z",gravity.z);
+      IFEM::cout <<" "<< gravity.z;
+    }
+    IFEM::cout << std::endl;
+  }
+  else
+    return false;
+
+  return true;
 }
 
 

--- a/ElasticBase.h
+++ b/ElasticBase.h
@@ -41,6 +41,9 @@ public:
   virtual Material* parseMatProp(const tinyxml2::XMLElement*, bool)
   { return nullptr; }
 
+  //! \brief Parses a data section from an XML-element.
+  virtual bool parse(const tinyxml2::XMLElement* elem);
+
   //! \brief Defines the material properties.
   virtual void setMaterial(Material*) {}
   //! \brief Returns the current material object.
@@ -49,8 +52,6 @@ public:
   //! \brief Initializes time integration parameters.
   virtual bool init(const TimeDomain&) { return true; }
 
-  //! \brief Defines the gravitation vector.
-  void setGravity(const Vec3& g) { gravity = g; }
   //! \brief Defines the gravitation vector.
   void setGravity(double gx, double gy = 0.0, double gz = 0.0)
   { gravity.x = gx; gravity.y = gy; gravity.z = gz; }

--- a/ElasticBase.h
+++ b/ElasticBase.h
@@ -17,6 +17,7 @@
 #include "IntegrandBase.h"
 #include "Vec3.h"
 
+class Material;
 namespace TimeIntegration { class BDFD2; }
 
 
@@ -33,6 +34,20 @@ protected:
 public:
   //! \brief The destructor deletes the BDF object, if any.
   virtual ~ElasticBase();
+
+  //! \brief Parses material properties from a character string.
+  virtual Material* parseMatProp(char*, bool) { return nullptr; }
+  //! \brief Parses material properties from an XML-element.
+  virtual Material* parseMatProp(const tinyxml2::XMLElement*, bool)
+  { return nullptr; }
+
+  //! \brief Defines the material properties.
+  virtual void setMaterial(Material*) {}
+  //! \brief Returns the current material object.
+  virtual Material* getMaterial() const { return nullptr; }
+
+  //! \brief Initializes time integration parameters.
+  virtual bool init(const TimeDomain&) { return true; }
 
   //! \brief Defines the gravitation vector.
   void setGravity(const Vec3& g) { gravity = g; }

--- a/Elasticity.C
+++ b/Elasticity.C
@@ -70,18 +70,8 @@ Elasticity::~Elasticity ()
 
 bool Elasticity::parse (const tinyxml2::XMLElement* elem)
 {
-  if (!strcasecmp(elem->Value(),"gravity"))
-  {
-    utl::getAttribute(elem,"x",gravity.x);
-    utl::getAttribute(elem,"y",gravity.y);
-    IFEM::cout <<"\tGravitation vector: "<< gravity.x <<" "<< gravity.y;
-    if (nsd == 3)
-    {
-      utl::getAttribute(elem,"z",gravity.z);
-      IFEM::cout <<" "<< gravity.z;
-    }
-    IFEM::cout << std::endl;
-  }
+  if (this->ElasticBase::parse(elem))
+    return true;
   else if (!strcasecmp(elem->Value(),"stabilization"))
   {
     utl::getAttribute(elem,"gamma",gamma);

--- a/Elasticity.h
+++ b/Elasticity.h
@@ -17,7 +17,6 @@
 #include "ElasticBase.h"
 
 class LocalSystem;
-class Material;
 class ElmNorm;
 class ElmMats;
 class Tensor;
@@ -80,10 +79,7 @@ public:
   //! \brief Defines the material properties.
   virtual void setMaterial(Material* mat);
   //! \brief Returns the current material object.
-  Material* getMaterial() const { return material; }
-
-  //! \brief Initializes time integration parameters.
-  virtual bool init(const TimeDomain&) { return true; }
+  virtual Material* getMaterial() const { return material; }
 
   //! \brief Defines the local coordinate system for stress output.
   void setLocalSystem(LocalSystem* cs) { locSys = cs; }

--- a/Linear/Test/SS45-Cable4p.reg
+++ b/Linear/Test/SS45-Cable4p.reg
@@ -4,6 +4,7 @@ Input file: SS45-Cable4p.xinp
 Equation solver: 2
 Number of Gauss points: 5
 Spline basis with C1-continuous patch interfaces is used
+Evaluation time for property functions: 1
 Solution component output zero tolerance: 1e-06
 Parsing input file SS45-Cable4p.xinp
 Parsing <geometry>
@@ -23,7 +24,7 @@ Parsing <boundaryconditions>
 	Dirichlet code 12: (fixed)
 Parsing <cable>
   Parsing <gravity>
-	Gravitation vector: 0 -9.81 0
+	Gravitation vector: 0 -9.81
   Parsing <material>
 	Axial stiffness = 7.85398e+08
 	Bending stiffness = 490873
@@ -53,6 +54,8 @@ Number of unknowns    24
 Number of quadrature points 50
 Processing integrand associated with code 0
 Assembling interior matrix terms for P1
+Done.
+Sum external load : 0 -3138.09 0
 Solving the equation system ...
 	Condition number: 11313.2
  >>> Solution summary <<<

--- a/SIMElasticity.h
+++ b/SIMElasticity.h
@@ -18,7 +18,7 @@
 #include "MatVec.h"
 #include "Vec3.h"
 
-class Elasticity;
+class ElasticBase;
 class Material;
 class TimeStep;
 struct TimeDomain;
@@ -89,7 +89,7 @@ protected:
   virtual bool preprocessB();
 
   //! \brief Returns the actual integrand.
-  virtual Elasticity* getIntegrand() = 0;
+  virtual ElasticBase* getIntegrand() = 0;
 
   //! \brief Parses the analytical solution from an input stream.
   virtual bool parseAnaSol(char*, std::istream&);

--- a/Shell/SIMKLShell.C
+++ b/Shell/SIMKLShell.C
@@ -69,9 +69,9 @@ KirchhoffLove* SIMKLShell::getProblem (int)
 }
 
 
-Elasticity* SIMKLShell::getIntegrand ()
+ElasticBase* SIMKLShell::getIntegrand ()
 {
-  return dynamic_cast<Elasticity*>(myProblem);
+  return dynamic_cast<ElasticBase*>(myProblem);
 }
 
 

--- a/Shell/SIMKLShell.h
+++ b/Shell/SIMKLShell.h
@@ -83,7 +83,7 @@ protected:
   //! \brief Returns the actual integrand.
   virtual KirchhoffLove* getProblem(int version = 1);
   //! \brief Returns the actual integrand.
-  virtual Elasticity* getIntegrand();
+  virtual ElasticBase* getIntegrand();
   //! \brief Parses a data section from the input stream.
   //! \param[in] keyWord Keyword of current data section to read
   //! \param is The file stream to read from

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -27,6 +27,7 @@ sidestreamRev[IFEM-NavierStokes]=master
 # Downstreams and revisions
 declare -a downstreams
 downstreams=(IFEM-BeamEx
+             IFEM-ShellEx
              IFEM-FiniteDeformation
              IFEM-ThermoElasticity
              IFEM-PoroElasticity
@@ -36,6 +37,7 @@ downstreams=(IFEM-BeamEx
 
 declare -A downstreamRev
 downstreamRev[IFEM-BeamEx]=master
+downstreamRev[IFEM-ShellEx]=master
 downstreamRev[IFEM-FiniteDeformation]=master
 downstreamRev[IFEM-ThermoElasticity]=master
 downstreamRev[IFEM-PoroElasticity]=master


### PR DESCRIPTION
The parsing of gravity vector is moved from class Elasticity to its parent class ElasticBase. The virtual method SIMElasticity::getIntegrand() then returns an ElasticBase pointer instead of Elasticity pointer.