### PR TITLE
Beam eccentricity support

### DIFF
--- a/Beam/BeamProperty.C
+++ b/Beam/BeamProperty.C
@@ -308,8 +308,8 @@ void BeamProperty::eval (const Vec3& X, double L,
   EI_y = EIyfunc ? (*EIyfunc)(X) : E*(Iyfunc ? (*Iyfunc)(X) : Iy);
   EI_z = EIzfunc ? (*EIzfunc)(X) : E*(Izfunc ? (*Izfunc)(X) : Iz);
   GI_t = GItfunc ? (*GItfunc)(X) : G*(Ixfunc ? (*Ixfunc)(X) : It);
-  Al_y = 12.0*(EI_y/(G*L*L)) * (Ayfunc ? (*Ayfunc)(X) : Ky/Area);
-  Al_z = 12.0*(EI_z/(G*L*L)) * (Azfunc ? (*Azfunc)(X) : Kz/Area);
+  Al_y = 12.0*(EI_y/(G*L*L)) * (Ayfunc ? 1.0 / (*Ayfunc)(X) : Ky / Area);
+  Al_z = 12.0*(EI_z/(G*L*L)) * (Azfunc ? 1.0 / (*Azfunc)(X) : Kz / Area);
   ItoA = (Ixfunc ? (*Ixfunc)(X) : It) / Area;
 
   S_y = Syfunc ? (*Syfunc)(X) : Sy;

--- a/Beam/BeamProperty.C
+++ b/Beam/BeamProperty.C
@@ -29,6 +29,7 @@ BeamProperty::BeamProperty (const tinyxml2::XMLElement* prop)
   Iy = Iz = 0.001;
   Ky = Kz = 0.0;
   Sy = Sz = 0.0;
+  phi = 0.0;
 
   EAfunc = EIyfunc = EIzfunc = GItfunc = nullptr;
   rhofunc = Ixfunc = Iyfunc = Izfunc = nullptr;
@@ -58,6 +59,21 @@ BeamProperty::~BeamProperty ()
   delete CGzfunc;
   delete Syfunc;
   delete Szfunc;
+}
+
+
+void BeamProperty::setConstant (const std::vector<double>& values)
+{
+  if (values.size() > 0) A   = values[0];
+  if (values.size() > 2) Ix  = values[1] + values[2];
+  if (values.size() > 1) Iy  = values[1];
+  if (values.size() > 2) Iz  = values[2];
+  if (values.size() > 3) It  = values[3];
+  if (values.size() > 4) Ky  = values[4];
+  if (values.size() > 5) Kz  = values[5];
+  if (values.size() > 6) Sy  = values[6];
+  if (values.size() > 7) Sz  = values[7];
+  if (values.size() > 8) phi = values[8];
 }
 
 

--- a/Beam/BeamProperty.h
+++ b/Beam/BeamProperty.h
@@ -14,10 +14,8 @@
 #ifndef _BEAM_PROPERTY_H
 #define _BEAM_PROPERTY_H
 
-#include <vector>
-#include <iostream>
+#include "Vec3.h"
 
-class Vec3;
 class RealFunc;
 namespace tinyxml2 { class XMLElement; }
 
@@ -36,6 +34,8 @@ public:
 
   //! \brief Initializes the constant property parameters.
   void setConstant(const std::vector<double>& values);
+  //! \brief Initializes the eccentricity vectors.
+  void setEccentric(const Vec3& e1, const Vec3& e2) { ecc1 = e1; ecc2 = e2; }
 
   //! \brief Parses beam cross section properties from an XML-element.
   void parse(const tinyxml2::XMLElement* prop);
@@ -102,7 +102,9 @@ public:
   double Ky; //!< Shear reduction factor in local Y-direction
   double Kz; //!< Shear reduction factor in local Z-direction
 
-private:
+  Vec3 ecc1; //!< Eccentricity vector at end 1
+  Vec3 ecc2; //!< Eccentricity vector at end 2
+
   double Sy; //!< Shear centre offset in local Y-direction
   double Sz; //!< Shear centre offset in local Z-direction
 

--- a/Beam/BeamProperty.h
+++ b/Beam/BeamProperty.h
@@ -14,6 +14,7 @@
 #ifndef _BEAM_PROPERTY_H
 #define _BEAM_PROPERTY_H
 
+#include <vector>
 #include <iostream>
 
 class Vec3;
@@ -32,6 +33,9 @@ public:
   explicit BeamProperty(const tinyxml2::XMLElement* prop = nullptr);
   //! \brief The destructor deallocates the property functions.
   ~BeamProperty();
+
+  //! \brief Initializes the constant property parameters.
+  void setConstant(const std::vector<double>& values);
 
   //! \brief Parses beam cross section properties from an XML-element.
   void parse(const tinyxml2::XMLElement* prop);
@@ -92,6 +96,8 @@ public:
   double Iy; //!< Second area moment around local Y-axis
   double Iz; //!< Second area moment around local Z-axis
   double It; //!< Torsional constant
+
+  double phi; //!< Angle between local element axes and principal axes
 
   double Ky; //!< Shear reduction factor in local Y-direction
   double Kz; //!< Shear reduction factor in local Z-direction

--- a/Linear/CMakeLists.txt
+++ b/Linear/CMakeLists.txt
@@ -86,7 +86,7 @@ if(LRSpline_FOUND OR LRSPLINE_FOUND)
   file(GLOB LRE_HDF5FILES RELATIVE ${PROJECT_SOURCE_DIR}/Test
                                    ${PROJECT_SOURCE_DIR}/Test/LR/*.hreg)
 endif()
-if(SPR_LIBRARIES)
+if(SPR_FOUND)
   file(GLOB SPR_TESTFILES RELATIVE ${PROJECT_SOURCE_DIR}/Test
                                    ${PROJECT_SOURCE_DIR}/Test/SPR/*.reg)
 endif()

--- a/Linear/Test/SPR/boatbeam.reg
+++ b/Linear/Test/SPR/boatbeam.reg
@@ -69,8 +69,8 @@ Done.
 Sum external load : 0 0 -4.10172e+06
 Solving the equation system ...
  >>> Solution summary <<<
-L2-norm            : 0.00329178
-Max Z-displacement : 0.0114064
+L2-norm            : 0.00476012
+Max Z-displacement : 0.0163602
 Max y-displacement : 0.000420108
 Integrating solution norms (FE solution) ...
-L2-norm: |u^h| = (u^h,u^h)^0.5     : 0.08097
+L2-norm: |u^h| = (u^h,u^h)^0.5     : 0.117128

--- a/Linear/Test/boatbeam.reg
+++ b/Linear/Test/boatbeam.reg
@@ -68,10 +68,10 @@ Assembling interior matrix terms for P1
 Done.
 Sum external load : 0 0 -4.10172e+06
 Solving the equation system ...
-	Condition number: 5.05508e+06
+	Condition number: 202773
  >>> Solution summary <<<
-L2-norm            : 0.00329178
-Max Z-displacement : 0.0114064
+L2-norm            : 0.00476012
+Max Z-displacement : 0.0163602
 Max y-displacement : 0.000420108
 Integrating solution norms (FE solution) ...
-L2-norm: |u^h| = (u^h,u^h)^0.5     : 0.08097
+L2-norm: |u^h| = (u^h,u^h)^0.5     : 0.117128


### PR DESCRIPTION
This adds the required transformation of the coefficient matrices for beam elements with eccentric end points (w.r.t. their neutral axes). Also a new method for assigning constant beam properties is added.

Requires OPM/IFEM#694