### PR TITLE
Cosmetics: Anonymization of unused argument

### DIFF
--- a/Beam/ElasticBar.C
+++ b/Beam/ElasticBar.C
@@ -324,9 +324,9 @@ double ElasticBar::getStrain (double LoverL0) const
 
 bool ElasticBar::finalizeElement (LocalIntegral& elmInt,
                                   const FiniteElement& fe,
-                                  const TimeDomain& time, size_t iGP)
+                                  const TimeDomain& time, size_t)
 {
-  bool ok = this->ElasticBase::finalizeElement(elmInt,time,iGP);
+  bool ok = this->finalizeElement(elmInt,time);
   if (!ok || npv > 2)
     return ok;
 

--- a/Beam/ElasticBar.h
+++ b/Beam/ElasticBar.h
@@ -79,12 +79,11 @@ public:
   //! \param elmInt The local integral object to receive the contributions
   //! \param[in] fe Nodal and integration point data for current element
   //! \param[in] time Parameters for nonlinear and time-dependent simulations
-  //! \param[in] iGP Global integration point counter of first point in element
   //!
   //! \details This method is used to shrink the element matrices
   //! in the case of two-dimensional geometry with two DOFs per node.
   virtual bool finalizeElement(LocalIntegral& elmInt, const FiniteElement& fe,
-                               const TimeDomain& time, size_t iGP);
+                               const TimeDomain& time, size_t);
 
 private:
   //! \brief Evaluates the axial strain.

--- a/Beam/ElasticBeam.C
+++ b/Beam/ElasticBeam.C
@@ -626,7 +626,7 @@ bool ElasticBeam::evalInt (LocalIntegral& elmInt,
 
 
 bool ElasticBeam::finalizeElement (LocalIntegral& elmInt,
-                                   const TimeDomain& time, size_t iGP)
+                                   const TimeDomain& time, size_t)
 {
   if (inLocalAxes)
   {
@@ -647,7 +647,7 @@ bool ElasticBeam::finalizeElement (LocalIntegral& elmInt,
           return false;
   }
 
-  return this->ElasticBase::finalizeElement(elmInt,time,iGP);
+  return this->ElasticBase::finalizeElement(elmInt,time);
 }
 
 

--- a/Beam/ElasticBeam.h
+++ b/Beam/ElasticBeam.h
@@ -81,9 +81,12 @@ public:
   //! \brief Finalizes the element matrices after the numerical integration.
   //! \param elmInt The local integral object to receive the contributions
   //! \param[in] time Parameters for nonlinear and time-dependent simulations
-  //! \param[in] iGP Global integration point counter of first point in element
+  //!
+  //! \details This method is used to transform the beam element matrices
+  //! from the local axes of the element to the global coordinate axes.
+  //! This also includes the effects of eccentric end points, if any.
   virtual bool finalizeElement(LocalIntegral& elmInt,
-                               const TimeDomain& time, size_t iGP);
+                               const TimeDomain& time, size_t);
 
   //! \brief Returns a pointer to an Integrand for solution norm evaluation.
   //! \note The Integrand object is allocated dynamically and has to be deleted

--- a/ElasticBase.h
+++ b/ElasticBase.h
@@ -32,7 +32,7 @@ protected:
   ElasticBase();
 
 public:
-  //! \brief The destructor deletes the BDF object, if any.
+  //! \brief The destructor deletes the BDFD2 object, if any.
   virtual ~ElasticBase();
 
   //! \brief Parses material properties from a character string.
@@ -75,7 +75,7 @@ public:
   //! \param[in] i Index of the integration parameter to return
   virtual double getIntegrationPrm(unsigned short int i) const;
 
-  //! \brief Advances the BDF time step scheme one step forward.
+  //! \brief Advances the %BDF time step scheme one step forward.
   void advanceStep(double dt, double dtn);
 
   //! \brief Returns whether this integrand has explicit boundary contributions.
@@ -105,7 +105,7 @@ public:
   //! integrand in case of a dynamics simulation, where it is needed to compute
   //! the effective stiffness/mass matrix used in the Newton iterations.
   virtual bool finalizeElement(LocalIntegral& elmInt,
-                               const TimeDomain& time, size_t);
+                               const TimeDomain& time, size_t = 0);
 
 protected:
   Vec3 gravity; //!< Gravitation vector

--- a/LinearElasticity.C
+++ b/LinearElasticity.C
@@ -385,7 +385,7 @@ bool LinearElasticity::formInitStrainForces (ElmMats& elMat, const Vector& N,
 
 bool LinearElasticity::finalizeElement (LocalIntegral& elmInt,
                                         const FiniteElement& fe,
-                                        const TimeDomain& time, size_t iGP)
+                                        const TimeDomain& time, size_t)
 {
   if (fe.iel > 0)
   {
@@ -396,5 +396,5 @@ bool LinearElasticity::finalizeElement (LocalIntegral& elmInt,
       myMmats[iel] = static_cast<ElmMats&>(elmInt).A[eM-1];
   }
 
-  return this->Elasticity::finalizeElement(elmInt,fe,time,iGP);
+  return this->finalizeElement(elmInt,time);
 }

--- a/LinearElasticity.h
+++ b/LinearElasticity.h
@@ -95,13 +95,16 @@ public:
                        const Vec3& X, const Vec3& normal) const;
 
   using Elasticity::finalizeElement;
-  //! \brief Finalizes the element quantities after the numerical integration.
+  //! \brief Finalizes the element matrices after the numerical integration.
   //! \param elmInt The local integral object to receive the contributions
   //! \param[in] fe Nodal and integration point data for current element
   //! \param[in] time Parameters for nonlinear and time-dependent simulations
-  //! \param[in] iGP Global integration point counter of first point in element
+  //!
+  //! \details This method is used to updates the element matrix buffers
+  //! \ref myKmats and \ref myMmats, in case initLHSbuffers() has been invoked
+  //! with \a nEl > 1 as argument.
   virtual bool finalizeElement(LocalIntegral& elmInt, const FiniteElement& fe,
-                               const TimeDomain& time, size_t iGP);
+                               const TimeDomain& time, size_t);
 
   //! \brief Returns which integrand to be used.
   virtual int getIntegrandType() const;

--- a/NewmarkDriver.h
+++ b/NewmarkDriver.h
@@ -53,12 +53,11 @@ protected:
     }
     else if (!strcasecmp(elem->Value(),"postprocessing"))
     {
-      const tinyxml2::XMLElement* respts = elem->FirstChildElement("resultpoints");
-      if (respts)
+      const tinyxml2::XMLElement* res = elem->FirstChildElement("resultpoints");
+      if (res)
         // The point file is used only for point and line output (not for grid)
-        if (respts->FirstChildElement("point") ||
-            respts->FirstChildElement("line"))
-          utl::getAttribute(respts,"file",rptFile);
+        if (res->FirstChildElement("point") || res->FirstChildElement("line"))
+          utl::getAttribute(res,"file",rptFile);
     }
 
     bool ok = this->Newmark::parse(elem);


### PR DESCRIPTION
Such that we can remove it from the doxy without issues.

Also, invoke the `finalizeElement()` method without the `FiniteElement` argument directly in `LinearElasticity::finalizeElement()` instead of going via the wrapper.