### PR TITLE
Minor NewmarkDriver refactoring

### DIFF
--- a/Linear/KirchhoffLovePlate.C
+++ b/Linear/KirchhoffLovePlate.C
@@ -309,7 +309,7 @@ bool KirchhoffLovePlate::evalSol (Vector& s, const Vectors& eV,
         s.push_back(q(1)*T(1,2) + q(2)*T(2,2));
       }
       else
-        s.insert(s.end(),q.begin(),q.end());
+        s.push_back(q.begin(),q.end());
     }
   }
   else

--- a/NonlinearDriver.h
+++ b/NonlinearDriver.h
@@ -105,8 +105,11 @@ public:
   //! \param[in] data Container for serialized data
   virtual bool deSerialize(const SerializeMap& data);
 
-  //! \brief Accesses the projected solution.
-  const Vector& getProjection() const { return proSol.front(); }
+  //! \brief Returns a pointer to the projected solution.
+  const Vector* getProjection() const
+  {
+    return proSol.empty() ? nullptr : proSol.data();
+  }
 
   //! \brief Overrides the stop time that was read from the input file.
   void setStopTime(double t) { params.stopTime = t; }

--- a/Shell/KirchhoffLoveShell.C
+++ b/Shell/KirchhoffLoveShell.C
@@ -253,7 +253,7 @@ bool KirchhoffLoveShell::evalSol (Vector& s, const Vectors& eV,
   if (!this->evalSol(s,sb,eV,fe,X,toLocal))
     return false;
   else
-    s.insert(s.end(),sb.begin(),sb.end());
+    s.push_back(sb.begin(),sb.end());
 
   // Calculate top and bottom surface stresses;
   // stress tensor components, principal stresses and von Mises stress
@@ -266,9 +266,9 @@ bool KirchhoffLoveShell::evalSol (Vector& s, const Vectors& eV,
       p[i] = (s[i] - isurf*sb[i]*6.0/thickness)/thickness;
 
     sigma.principal(sigma_p);
-    s.insert(s.end(),sigma.ptr(),sigma.ptr()+3);
-    s.insert(s.end(),sigma_p.ptr(),sigma_p.ptr()+2);
-    s.insert(s.end(),sigma.vonMises());
+    s.push_back(sigma.ptr(),sigma.ptr()+3);
+    s.push_back(sigma_p.ptr(),sigma_p.ptr()+2);
+    s.push_back(sigma.vonMises());
   }
 
   return true;
@@ -346,7 +346,7 @@ void KirchhoffLoveShell::primaryScalarFields (Matrix& field)
   // Insert the absolute value as the fourth solution component
   double* u = new double[field.cols()];
   for (size_t c = 1; c <= field.cols(); c++)
-    u[c-1] = field.getColumn(c).norm2();
+    u[c-1] = Vec3(field.getColumn(c)).length();
   field.expandRows(1);
   field.fillRow(4,u);
   delete[] u;


### PR DESCRIPTION
Basically, the type of the `projSol` member is changed from `Matrix` to `Vectors`, to be aligned with the sibling driver for quasi-static problems, `NonlinearDriver`. Also using the new `utl::vector::push_back()` methods instead of `insert()`.

Requires OPM/IFEM#738