### PR TITLE
Various updates

### DIFF
--- a/Linear/DynamicDriver.C
+++ b/Linear/DynamicDriver.C
@@ -67,6 +67,8 @@ int dynamicSim (char* infile, SIMoutput* model, bool fixDup,
     writer->registerWriter(new HDF5Writer(fileName,model->getProcessAdm()));
 
     int results = DataExporter::PRIMARY | DataExporter::DISPLACEMENT;
+    if (!model->opt.pSolOnly) results |= DataExporter::SECONDARY;
+    if (model->opt.saveNorms) results |= DataExporter::NORMS;
     writer->registerField("u","solution",DataExporter::SIM,results);
     writer->setFieldValue("u",model,&simulator.getSolution());
     results = -DataExporter::PRIMARY;

--- a/Linear/DynamicSim.h
+++ b/Linear/DynamicSim.h
@@ -50,4 +50,16 @@ int modalSim (char* infile, size_t nM, bool dumpModes, bool qstatic,
 int dynamicSim (char* infile, SIMoutput* model, bool fixDup = false,
                 double zero_tol = 1.0e-8, std::streamsize outPrec = 6);
 
+/*!
+  \brief Driver creating a time history from a set of eigenmode shapes.
+  \param[in] infile The input file to parse for time integration setup
+  \param model The isogeometric finite element model
+  \param[in] zero_tol Truncate result values smaller than this to zero
+  \param[in] outPrec Number of digits after the decimal point in result print
+  \return Exit status
+*/
+
+int modeHistSim (char* infile, SIMoutput* model,
+                 double zero_tol = 1.0e-8, std::streamsize outPrec = 6);
+
 #endif

--- a/Linear/ModalDriver.h
+++ b/Linear/ModalDriver.h
@@ -16,6 +16,7 @@
 
 #include "NewmarkDriver.h"
 #include "NewmarkSIM.h"
+#include "EigenModeSIM.h"
 
 
 /*!
@@ -28,9 +29,6 @@ public:
   //! \brief The constructor forwards to the parent class constructor.
   explicit ModalDriver(SIMbase& sim, bool qs = false)
     : NewmarkDriver<NewmarkSIM>(sim) { qstatic = qs; }
-
-  //! \brief Empty destructor.
-  virtual ~ModalDriver() {}
 
   //! \brief Calculates/returns the current real solution vectors.
   virtual const Vectors& realSolutions(bool returnCurrent);
@@ -60,6 +58,30 @@ public:
 
 private:
   bool qstatic; //!< If \e true, use quasi-static simulation driver
+};
+
+
+/*!
+  \brief Driver creating a time history from a set of eigenmode shapes.
+*/
+
+class ModesHistorySIM : public EigenModeSIM
+{
+public:
+  //! \brief The constructor forwards to the parent class constructor.
+  explicit ModesHistorySIM(SIMbase& sim) : EigenModeSIM(sim) {}
+
+protected:
+  using EigenModeSIM::parse;
+  //! \brief Parses a data section from an XML document.
+  virtual bool parse(const tinyxml2::XMLElement* elem);
+
+public:
+  //! \brief Initializes the solver and runs through the time history.
+  int solve(char* infile, double ztol = 1.0e-8, std::streamsize outPrec = 0);
+
+private:
+  TimeStep params; //!< Time stepping parameters
 };
 
 #endif

--- a/Linear/MultiLoadCaseDriver.C
+++ b/Linear/MultiLoadCaseDriver.C
@@ -1,0 +1,82 @@
+// $Id$
+//==============================================================================
+//!
+//! \file MultiLoadCaseDriver.C
+//!
+//! \date May 05 2024
+//!
+//! \author Knut Morten Okstad / SINTEF
+//!
+//! \brief Driver for linear multi-load-case static problems.
+//!
+//==============================================================================
+
+#include "IFEM.h"
+#include "SIMoutput.h"
+#include "NonlinearDriver.h"
+#include "ElasticityUtils.h"
+#include "DataExporter.h"
+#include "HDF5Writer.h"
+#include "Profiler.h"
+
+
+int mlcSim (char* infile, SIMoutput* model, bool fixDup, bool dumpNodeMap,
+            double zero_tol, std::streamsize outPrec)
+{
+  IFEM::cout <<"\nUsing the multi-load-case simulation driver."<< std::endl;
+  NonlinearDriver simulator(*model,true);
+
+  // Read in solver and model definitions
+  if (!simulator.read(infile))
+    return 1;
+
+  // Let the stop time specified on command-line override input file setting
+  if (Elastic::time > 1.0)
+    simulator.setStopTime(Elastic::time);
+
+  model->opt.print(IFEM::cout,true) << std::endl;
+  simulator.printProblem();
+
+  utl::profiler->stop("Model input");
+
+  // Preprocess the model and establish data structures for the algebraic system
+  if (!model->preprocess({},fixDup))
+    return 2;
+
+  // Save FE model to VTF file for visualization
+  if (model->opt.format >= 0 && !simulator.saveModel(infile))
+    return 3;
+
+  // Initialize the solution vectors
+  simulator.initPrm();
+  simulator.initSol();
+
+  // Initialize the linear equation solver
+  if (!simulator.initEqSystem())
+    return 3;
+
+  // Open HDF5 result database, if requested
+  DataExporter* writer = nullptr;
+  if (model->opt.dumpHDF5(infile))
+  {
+    const std::string& fileName = model->opt.hdf5;
+    IFEM::cout <<"\nWriting HDF5 file "<< fileName <<".hdf5"<< std::endl;
+
+    writer = new DataExporter(true,model->opt.saveInc);
+    writer->registerWriter(new HDF5Writer(fileName,model->getProcessAdm()));
+
+    int results = DataExporter::PRIMARY | DataExporter::DISPLACEMENT;
+    if (!model->opt.pSolOnly) results |= DataExporter::SECONDARY;
+    if (model->opt.saveNorms) results |= DataExporter::NORMS;
+    if (dumpNodeMap) results |= DataExporter::L2G_NODE;
+    writer->registerField("u","solution",DataExporter::SIM,results);
+    writer->setFieldValue("u",model,
+                          &simulator.getSolution(),nullptr,
+                          simulator.getNorms());
+  }
+
+  // Now invoke the main solution driver
+  int status = simulator.solveProblem(writer,nullptr,zero_tol,outPrec);
+  delete writer;
+  return status;
+}

--- a/Linear/MultiLoadCaseSim.h
+++ b/Linear/MultiLoadCaseSim.h
@@ -1,0 +1,37 @@
+// $Id$
+//==============================================================================
+//!
+//! \file MultiLoadCaseSim.h
+//!
+//! \date May 05 2024
+//!
+//! \author Knut Morten Okstad / SINTEF
+//!
+//! \brief Driver for linear multi-load-case static problems.
+//!
+//==============================================================================
+
+#ifndef _MULTI_LOAD_CASE_SIM_H
+#define _MULTI_LOAD_CASE_SIM_H
+
+#include <ios>
+
+class SIMoutput;
+
+
+/*!
+  \brief Driver for modal simulation of linear dynamics problems.
+  \param[in] infile The input file to parse for load case setup
+  \param model The isogeometric finite element model
+  \param[in] fixDup If \e true, merge duplicated FE nodes
+  \param[in] dumpNodeMap If \e true, export node mapping to HDF5 file
+  \param[in] zero_tol Truncate result values smaller than this to zero
+  \param[in] outPrec Number of digits after the decimal point in result print
+  \return Exit status
+*/
+
+int mlcSim (char* infile, SIMoutput* model,
+            bool fixDup = false, bool dumpNodeMap = false,
+            double zero_tol = 1.0e-8, std::streamsize outPrec = 6);
+
+#endif

--- a/NewmarkDriver.h
+++ b/NewmarkDriver.h
@@ -196,6 +196,9 @@ public:
     return proSol.empty() ? nullptr : proSol.data();
   }
 
+  //! \brief Dummy method required for template instantiation.
+  Matrix* getNorms() { return nullptr; }
+
   //! \brief Overrides the stop time that was read from the input file.
   void setStopTime(double t) { params.stopTime = t; }
 

--- a/NonlinearDriver.C
+++ b/NonlinearDriver.C
@@ -122,7 +122,7 @@ bool NonlinearDriver::solutionNorms (const TimeDomain& time,
   {
     model.setMode(SIM::NORMS);
     model.setQuadratureRule(opt.nGauss[1]);
-    if (!model.solutionNorms(time,solution,gNorm))
+    if (!model.solutionNorms(time,solution,gNorm,this->getNorms()))
       gNorm.clear();
   }
   else
@@ -349,6 +349,9 @@ int NonlinearDriver::solveProblem (DataExporter* writer, HDF5Restart* restart,
           if (!model.writeGlvN(eNorm,iStep,nBlock,{pit->second}))
             return 11;
         }
+        else // Write element norms without projections
+          if (!model.writeGlvN(eNorm,iStep,nBlock))
+            return 11;
       }
 
       if (elp) elp->enableMaxValCalc(false);

--- a/NonlinearDriver.h
+++ b/NonlinearDriver.h
@@ -111,6 +111,12 @@ public:
     return proSol.empty() ? nullptr : proSol.data();
   }
 
+  //! \brief Returns a pointer to the element norms, if they are to be saved.
+  Matrix* getNorms()
+  {
+    return opt.saveNorms ? &eNorm : nullptr;
+  }
+
   //! \brief Overrides the stop time that was read from the input file.
   void setStopTime(double t) { params.stopTime = t; }
 


### PR DESCRIPTION
* Command-line options `-mlc` for performing multi-load-case analysis (like for ShellSim).
* Saving element norms to VTF and HDF5-file also when projection is not used.
* Saving secondary variables to HDF5 for linear dynamics simulation.