### PR TITLE
Cosmetic change in problem definition print out

### DIFF
--- a/Beam/SIMElasticBar.C
+++ b/Beam/SIMElasticBar.C
@@ -48,12 +48,12 @@ SIMElasticBar::~SIMElasticBar ()
 }
 
 
-void SIMElasticBar::printProblem () const
+bool SIMElasticBar::printProblem () const
 {
-  if (!printed)
-    this->SIM1D::printProblem();
+  // Avoid printing problem definition more than once
+  if (printed) return false;
 
-  printed = true; // Avoid printing problem definition more than once
+  return printed = this->SIM1D::printProblem();
 }
 
 

--- a/Beam/SIMElasticBar.h
+++ b/Beam/SIMElasticBar.h
@@ -37,7 +37,7 @@ public:
   virtual ~SIMElasticBar();
 
   //! \brief Prints out problem-specific data to the log stream.
-  virtual void printProblem() const;
+  virtual bool printProblem() const;
 
   //! \brief Creates the computational FEM model from the spline patches.
   //! \details Reimplemented to account for twist angle in beam problems.

--- a/SIMElasticity.C
+++ b/SIMElasticity.C
@@ -119,8 +119,8 @@ template<class Dim>
 SIMElasticity<Dim>::SIMElasticity (bool checkRHS) : Dim(Dim::dimension,checkRHS)
 {
   myContext = "elasticity";
+  plotRgd = printed = false;
   aCode = 0;
-  plotRgd = false;
 }
 
 
@@ -133,6 +133,16 @@ SIMElasticity<Dim>::~SIMElasticity ()
 
   for (Material* mat : mVec)
     delete mat;
+}
+
+
+template<class Dim>
+bool SIMElasticity<Dim>::printProblem () const
+{
+  // Avoid printing problem definition more than once
+  if (printed) return false;
+
+  return printed = this->Dim::printProblem();
 }
 
 

--- a/SIMElasticity.h
+++ b/SIMElasticity.h
@@ -23,7 +23,7 @@ class Material;
 class TimeStep;
 struct TimeDomain;
 
-typedef std::vector<Material*> MaterialVec; //!< Convenience declaration
+using MaterialVec = std::vector<Material*>; //!< Convenience declaration
 
 
 /*!
@@ -42,6 +42,9 @@ public:
 
   //! \brief The destructor frees the dynamically allocated material properties.
   virtual ~SIMElasticity();
+
+  //! \brief Prints out problem-specific data to the log stream.
+  virtual bool printProblem() const;
 
   //! \brief Returns the name of this simulator (for use in the HDF5 export).
   virtual std::string getName() const { return "Elasticity"; }
@@ -160,6 +163,8 @@ protected:
 private:
   bool plotRgd; //!< If \e true, output rigid couplings as VTF geometry
   int  aCode;   //!< Analytical BC code (used by destructor)
+
+  mutable bool printed; //!< If \e true, the problem definition as been printed
 };
 
 #endif

--- a/Shell/main.C
+++ b/Shell/main.C
@@ -41,8 +41,7 @@ int runSimulator (Simulator& simulator, SIMbase& model, char* infile,
     simulator.setStopTime(stopTime);
 
   model.opt.print(IFEM::cout,true) << std::endl;
-
-  utl::profiler->stop("Model input");
+  simulator.printProblem(true);
 
   // Preprocess the model and establish data structures for the algebraic system
   if (!model.preprocess())


### PR DESCRIPTION
Avoid printing twice from multi-step simulators, and force stopping model input timer when printing problem data, assuming the inout should be complete at this stage (just for the convenience).

Requires OPM/IFEM#753 (due to virtual method signature change)