### PR TITLE
Minor changes with downstreams implications

### DIFF
--- a/ElasticBase.h
+++ b/ElasticBase.h
@@ -36,9 +36,9 @@ public:
   virtual ~ElasticBase();
 
   //! \brief Parses material properties from a character string.
-  virtual Material* parseMatProp(char*, bool) { return nullptr; }
+  virtual Material* parseMatProp(char* = nullptr) { return nullptr; }
   //! \brief Parses material properties from an XML-element.
-  virtual Material* parseMatProp(const tinyxml2::XMLElement*, bool)
+  virtual Material* parseMatProp(const tinyxml2::XMLElement*)
   { return nullptr; }
 
   //! \brief Parses a data section from an XML-element.

--- a/Elasticity.C
+++ b/Elasticity.C
@@ -12,6 +12,7 @@
 //==============================================================================
 
 #include "Elasticity.h"
+#include "ElasticityUtils.h"
 #include "GlobalIntegral.h"
 #include "IsotropicTextureMat.h"
 #include "FiniteElement.h"
@@ -86,24 +87,28 @@ bool Elasticity::parse (const tinyxml2::XMLElement* elem)
 }
 
 
-Material* Elasticity::parseMatProp (char* cline, bool planeStrain)
+Material* Elasticity::parseMatProp (char* cline)
 {
+  bool planeStress = nsd == 2 ? !Elastic::planeStrain : false;
+
   double E   = atof(strtok(cline," "));
   double nu  = atof(strtok(nullptr," "));
   double rho = atof(strtok(nullptr," "));
   IFEM::cout << E <<" "<< nu <<" "<< rho << std::endl;
-  material = new LinIsotropic(E,nu,rho,!planeStrain,axiSymmetry);
+  material = new LinIsotropic(E,nu,rho,planeStress,axiSymmetry);
   return material;
 }
 
 
-Material* Elasticity::parseMatProp (const tinyxml2::XMLElement* elem,
-                                    bool planeStrain)
+Material* Elasticity::parseMatProp (const tinyxml2::XMLElement* elem)
 {
+  utl::getAttribute(elem,"planeStrain",Elastic::planeStrain);
+  bool planeStress = nsd == 2 ? !Elastic::planeStrain : false;
+
   if (!strcasecmp(elem->Value(),"texturematerial"))
-    material = new IsotropicTextureMat(!planeStrain,axiSymmetry);
+    material = new IsotropicTextureMat(planeStress,axiSymmetry);
   else
-    material = new LinIsotropic(!planeStrain,axiSymmetry);
+    material = new LinIsotropic(planeStress,axiSymmetry);
   material->parse(elem);
   return material;
 }

--- a/Elasticity.h
+++ b/Elasticity.h
@@ -47,10 +47,9 @@ public:
   virtual ~Elasticity();
 
   //! \brief Parses material properties from a character string.
-  virtual Material* parseMatProp(char* cline, bool planeStrain = true);
+  virtual Material* parseMatProp(char* cline);
   //! \brief Parses material properties from an XML-element.
-  virtual Material* parseMatProp(const tinyxml2::XMLElement* elem,
-                                 bool planeStrain = true);
+  virtual Material* parseMatProp(const tinyxml2::XMLElement* elem);
 
   //! \brief Parses local coordinate system definition from a character string.
   bool parseLocalSystem(const char* cline);


### PR DESCRIPTION
Move extraction of planeStrain attribute inside Elasticity::parseMatProp().
Respect that the virtual method getIntegrand() also may return a null pointer.