### PR TITLE
Changed: Use SIM::RHS_ONLY mode also for dynamics problems

### DIFF
--- a/Beam/ElasticBeam.h
+++ b/Beam/ElasticBeam.h
@@ -119,6 +119,9 @@ protected:
   void getMassMatrix(Matrix& EM, double rhoA, double Ixx,
                      double Iyy, double Izz, double L) const;
 
+private:
+  mutable enum { STD, DYN, HHT } myType; //!< Enum for element matrix type
+
 protected:
   // Material property parameters (constant)
   double E;   //!< Young's modulus

--- a/ElasticBase.h
+++ b/ElasticBase.h
@@ -49,8 +49,9 @@ public:
   virtual bool init(const TimeDomain&) { return true; }
 
   //! \brief Defines the solution mode before the element assembly is started.
-  //! \param[in] mode The solution mode to use
   virtual void setMode(SIM::SolutionMode mode);
+  //! \brief Returns current solution mode.
+  virtual SIM::SolutionMode getMode(bool simMode) const;
   //! \brief Updates the external load vector index for gradient calculation.
   void setLoadGradientMode() { eS = 2; }
 

--- a/KirchhoffLove.h
+++ b/KirchhoffLove.h
@@ -48,8 +48,9 @@ public:
   virtual bool parse(const tinyxml2::XMLElement* elem);
 
   //! \brief Defines the solution mode before the element assembly is started.
-  //! \param[in] mode The solution mode to use
   virtual void setMode(SIM::SolutionMode mode);
+  //! \brief Returns current solution mode.
+  virtual SIM::SolutionMode getMode(bool simMode) const;
   //! \brief Updates the external load vector index for gradient calculation.
   void setLoadGradientMode() { eS = 2; }
 

--- a/Linear/Test/CanTS2D-p2-dmp.xinp
+++ b/Linear/Test/CanTS2D-p2-dmp.xinp
@@ -46,6 +46,7 @@
   </discretization>
 
   <newmarksolver alpha2="0.003">
+    <nupdate>0</nupdate>
     <timestepping>
       <step start="0.0" end="2.0">0.05</step>
     </timestepping>

--- a/Linear/Test/CanTS2D-p2-dyn.xinp
+++ b/Linear/Test/CanTS2D-p2-dyn.xinp
@@ -46,6 +46,7 @@
   </discretization>
 
   <newmarksolver>
+    <nupdate>0</nupdate>
     <timestepping>
       <step start="0.0" end="2.0">0.05</step>
     </timestepping>

--- a/Linear/Test/RectPlate-modal.xinp
+++ b/Linear/Test/RectPlate-modal.xinp
@@ -35,6 +35,7 @@
   </discretization>
 
   <newmarksolver alpha2="0.001">
+    <nupdate>0</nupdate>
     <timestepping>
       <step start="0.0" end="5.0">0.05</step>
     </timestepping>

--- a/Linear/Test/Utkrager-dyn.reg
+++ b/Linear/Test/Utkrager-dyn.reg
@@ -37,7 +37,7 @@ ElasticBeam: E = 2.05e+11, G = 8.1e+10, rho = 7850
              A = 0.1, Ix = 0.002, Iy = 0.001, Iz = 0.001, It = 0.002
              Ky = 1.2, Kz = 1.2, Sy = 0, Sz = 0
 Newmark predictor/multicorrector: beta = 0.25 gamma = 0.5
- updating coefficient matrices in the first 20 iterations in each time step
+ using constant coefficient matrices
  using zero acceleration predictor
 Stiffness-proportional damping (alpha2): 0.003
 11. Linear Elastic Beam solver

--- a/Linear/Test/Utkrager.xinp
+++ b/Linear/Test/Utkrager.xinp
@@ -24,6 +24,7 @@
   </beam>
 
   <newmarksolver alpha2="0.003">
+    <nupdate>0</nupdate>
     <timestepping>
       <step start="0.0" end="2.0">0.05</step>
     </timestepping>


### PR DESCRIPTION
To avoid the unnecessary assembly of coefficient matrices.
Downstream of OPM/IFEM#764.