### PR TITLE
Added: Let BeamProperty::parseBox() also handle hollow Box-sections

### DIFF
--- a/Beam/BeamProperty.h
+++ b/Beam/BeamProperty.h
@@ -39,11 +39,14 @@ public:
 
   //! \brief Parses beam cross section properties from an XML-element.
   void parse(const tinyxml2::XMLElement* prop);
+
   //! \brief Parses circular cross section properties from an XML-element.
-  static bool parsePipe(const tinyxml2::XMLElement* prop, double& A, double& I);
-  //! \brief Parses massive box cross section properties from an XML-element.
-  static bool parseBox(const tinyxml2::XMLElement* prop, double& A,
-                       double& Iy, double& Iz, double& It);
+  static bool parsePipe(const tinyxml2::XMLElement* prop, double& A, double& I,
+                        double* K = nullptr);
+  //! \brief Parses box cross section properties from an XML-element.
+  static bool parseBox(const tinyxml2::XMLElement* prop,
+                       double& A, double& I1, double& I2, double& J,
+                       double* K1 = nullptr, double* K2 = nullptr);
 
   //! \brief Evaluates the beam properties at the specified point \a X.
   void eval(const Vec3& X, double L, double E, double G, double rho,
@@ -107,16 +110,10 @@ public:
 
   double Sy; //!< Shear centre offset in local Y-direction
   double Sz; //!< Shear centre offset in local Z-direction
-
-  //! \brief Output stream operator.
-  friend std::ostream& operator<<(std::ostream& os, const BeamProperty& prop)
-  {
-    return os <<"\n             A = "<< prop.A
-              <<", Ix = "<< prop.Ix <<", Iy = "<< prop.Iy
-              <<", Iz = "<< prop.Iz <<", It = "<< prop.It
-              <<"\n             Ky = "<< prop.Ky <<", Kz = "<< prop.Kz
-              <<", Sy = "<< prop.Sy <<", Sz = "<< prop.Sz;
-  }
 };
+
+
+//! \brief Global output stream operator.
+std::ostream& operator<<(std::ostream& os, const BeamProperty& prop);
 
 #endif

--- a/Linear/Test/Beam+KLcyl-p3.reg
+++ b/Linear/Test/Beam+KLcyl-p3.reg
@@ -88,8 +88,8 @@ Number of constraints 156
 Number of unknowns    90
 12. Linear Elastic Beam solver
 Problem definition:
-ElasticBeam: E = 2.1e+11, G = 8.07692e+10, rho = 7850
-             A = 0.00596903, Ix = 5.40197e-05, Iy = 2.70098e-05, Iz = 2.70098e-05, It = 5.40197e-05
+ElasticBeam: E = 2.1e+11, G = 8.07692e+10, rho = 7850, A = 0.00596903
+             Ix = 5.40197e-05, Iy = 2.70098e-05, Iz = 2.70098e-05, It = 5.40197e-05
              Ky = 2, Kz = 2, Sy = 0, Sz = 0
 Resolving Dirichlet boundary conditions
 	Constraining P1 V1 in direction(s) 12345

--- a/Linear/Test/Beam+Uprofil-p2.reg
+++ b/Linear/Test/Beam+Uprofil-p2.reg
@@ -98,8 +98,8 @@ Number of constraints 312
 Number of unknowns    792
 12. Linear Elastic Beam solver
 Problem definition:
-ElasticBeam: E = 2.1e+11, G = 8.07692e+10, rho = 7850
-             A = 0.12, Ix = 0.004, Iy = 0.0004, Iz = 0.0036, It = 0.00126435
+ElasticBeam: E = 2.1e+11, G = 8.07692e+10, rho = 7850, A = 0.12
+             Ix = 0.004, Iy = 0.0004, Iz = 0.0036, It = 0.00126435
              Ky = 1.2, Kz = 1.2, Sy = 0, Sz = 0
 Resolving Dirichlet boundary conditions
 	Constraining P1 V2 in direction(s) 12346

--- a/Linear/Test/Beam+supel.reg
+++ b/Linear/Test/Beam+supel.reg
@@ -60,8 +60,8 @@ Number of dofs        12
 Number of unknowns    12
 12. Linear Elastic Beam solver
 Problem definition:
-ElasticBeam: E = 2.1e+11, G = 8.07692e+10, rho = 7850
-             A = 0.12, Ix = 0.004, Iy = 0.0004, Iz = 0.0036, It = 0.00126435
+ElasticBeam: E = 2.1e+11, G = 8.07692e+10, rho = 7850, A = 0.12
+             Ix = 0.004, Iy = 0.0004, Iz = 0.0036, It = 0.00126435
              Ky = 1.2, Kz = 1.2, Sy = 0, Sz = 0
 Resolving Dirichlet boundary conditions
 	Constraining P1 V2 in direction(s) 12346

--- a/Linear/Test/BeamFrame.reg
+++ b/Linear/Test/BeamFrame.reg
@@ -49,8 +49,8 @@ Parsing input file succeeded.
 Equation solver: 2
 Number of Gauss points: 1
 Problem definition:
-ElasticBeam: E = 2.1e+11, G = 8.1e+10, rho = 7850
-             A = 0.00149226, Ix = 3.37623e-06, Iy = 1.68812e-06, Iz = 1.68812e-06, It = 3.37623e-06
+ElasticBeam: E = 2.1e+11, G = 8.1e+10, rho = 7850, A = 0.00149226
+             Ix = 3.37623e-06, Iy = 1.68812e-06, Iz = 1.68812e-06, It = 3.37623e-06
              Ky = 2, Kz = 2, Sy = 0, Sz = 0
 Renumbered 10 nodes.
 Resolving Dirichlet boundary conditions

--- a/Linear/Test/NREL_5MW_blade-vibration.reg
+++ b/Linear/Test/NREL_5MW_blade-vibration.reg
@@ -53,8 +53,8 @@ Shift value: 0
 Number of Gauss points: 1
 11. Linear Elastic Beam solver
 Problem definition:
-ElasticBeam: E = 2.05e+11, G = 7.94e+10, rho = 7850
-             A = 0.1, Ix = 0, Iy = 0.001, Iz = 0.001, It = 0.002
+ElasticBeam: E = 2.05e+11, G = 7.94e+10, rho = 7850, A = 0.1
+             Ix = 0, Iy = 0.001, Iz = 0.001, It = 0.002
              Ky = 0, Kz = 0, Sy = 0, Sz = 0
 Resolving Dirichlet boundary conditions
 	Constraining P1 V1 in direction(s) 123456

--- a/Linear/Test/SPR/Beam+KLcyl-p3.reg
+++ b/Linear/Test/SPR/Beam+KLcyl-p3.reg
@@ -88,8 +88,8 @@ Number of constraints 156
 Number of unknowns    90
 12. Linear Elastic Beam solver
 Problem definition:
-ElasticBeam: E = 2.1e+11, G = 8.07692e+10, rho = 7850
-             A = 0.00596903, Ix = 5.40197e-05, Iy = 2.70098e-05, Iz = 2.70098e-05, It = 5.40197e-05
+ElasticBeam: E = 2.1e+11, G = 8.07692e+10, rho = 7850, A = 0.0059690
+             Ix = 5.40197e-05, Iy = 2.70098e-05, Iz = 2.70098e-05, It = 5.40197e-05
              Ky = 2, Kz = 2, Sy = 0, Sz = 0
 Resolving Dirichlet boundary conditions
 	Constraining P1 V1 in direction(s) 12345

--- a/Linear/Test/SPR/Beam+Uprofil-p2.reg
+++ b/Linear/Test/SPR/Beam+Uprofil-p2.reg
@@ -98,8 +98,8 @@ Number of constraints 312
 Number of unknowns    792
 12. Linear Elastic Beam solver
 Problem definition:
-ElasticBeam: E = 2.1e+11, G = 8.07692e+10, rho = 7850
-             A = 0.12, Ix = 0.004, Iy = 0.0004, Iz = 0.0036, It = 0.00126435
+ElasticBeam: E = 2.1e+11, G = 8.07692e+10, rho = 7850, A = 0.1
+             Ix = 0.004, Iy = 0.0004, Iz = 0.0036, It = 0.00126435
              Ky = 1.2, Kz = 1.2, Sy = 0, Sz = 0
 Resolving Dirichlet boundary conditions
 	Constraining P1 V2 in direction(s) 12346

--- a/Linear/Test/SPR/Beam+supel.reg
+++ b/Linear/Test/SPR/Beam+supel.reg
@@ -60,8 +60,8 @@ Number of dofs        12
 Number of unknowns    12
 12. Linear Elastic Beam solver
 Problem definition:
-ElasticBeam: E = 2.1e+11, G = 8.07692e+10, rho = 7850
-             A = 0.12, Ix = 0.004, Iy = 0.0004, Iz = 0.0036, It = 0.00126435
+ElasticBeam: E = 2.1e+11, G = 8.07692e+10, rho = 7850, A = 0.12
+             Ix = 0.004, Iy = 0.0004, Iz = 0.0036, It = 0.00126435
              Ky = 1.2, Kz = 1.2, Sy = 0, Sz = 0
 Resolving Dirichlet boundary conditions
 	Constraining P1 V2 in direction(s) 12346

--- a/Linear/Test/SPR/BeamFrame.reg
+++ b/Linear/Test/SPR/BeamFrame.reg
@@ -49,8 +49,8 @@ Parsing input file succeeded.
 Equation solver: 1
 Number of Gauss points: 1
 Problem definition:
-ElasticBeam: E = 2.1e+11, G = 8.1e+10, rho = 7850
-             A = 0.00149226, Ix = 3.37623e-06, Iy = 1.68812e-06, Iz = 1.68812e-06, It = 3.37623e-06
+ElasticBeam: E = 2.1e+11, G = 8.1e+10, rho = 7850, A = 0.0014922
+             Ix = 3.37623e-06, Iy = 1.68812e-06, Iz = 1.68812e-06, It = 3.37623e-06
              Ky = 2, Kz = 2, Sy = 0, Sz = 0
 Renumbered 10 nodes.
 Resolving Dirichlet boundary conditions

--- a/Linear/Test/SPR/NREL_5MW_blade-vibration.reg
+++ b/Linear/Test/SPR/NREL_5MW_blade-vibration.reg
@@ -51,8 +51,8 @@ Shift value: 0
 Number of Gauss points: 1
 11. Linear Elastic Beam solver
 Problem definition:
-ElasticBeam: E = 2.05e+11, G = 7.94e+10, rho = 7850
-             A = 0.1, Ix = 0, Iy = 0.001, Iz = 0.001, It = 0.002
+ElasticBeam: E = 2.05e+11, G = 7.94e+10, rho = 7850, A = 0.1
+             Ix = 0, Iy = 0.001, Iz = 0.001, It = 0.002
              Ky = 0, Kz = 0, Sy = 0, Sz = 0
 Resolving Dirichlet boundary conditions
 	Constraining P1 V1 in direction(s) 123456

--- a/Linear/Test/SPR/Utkrager.reg
+++ b/Linear/Test/SPR/Utkrager.reg
@@ -27,8 +27,8 @@ Parsing input file succeeded.
 Equation solver: 1
 Number of Gauss points: 1
 Problem definition:
-ElasticBeam: E = 2.05e+11, G = 8.1e+10, rho = 7850
-             A = 0.1, Ix = 0.002, Iy = 0.001, Iz = 0.001, It = 0.002
+ElasticBeam: E = 2.05e+11, G = 8.1e+10, rho = 7850, A = 0.1
+             Ix = 0.002, Iy = 0.001, Iz = 0.001, It = 0.002
              Ky = 1.2, Kz = 1.2, Sy = 0, Sz = 0
 Resolving Dirichlet boundary conditions
 	Constraining P1 V1 in direction(s) 123456

--- a/Linear/Test/SPR/boatbeam.reg
+++ b/Linear/Test/SPR/boatbeam.reg
@@ -51,8 +51,8 @@ Equation solver: 1
 Number of Gauss points: 1
 11. Linear Elastic Beam solver
 Problem definition:
-ElasticBeam: E = 2.05e+11, G = 7.94e+10, rho = 7850
-             A = 0.1, Ix = 0.002, Iy = 0.001, Iz = 0.001, It = 0.002
+ElasticBeam: E = 2.05e+11, G = 7.94e+10, rho = 7850, A = 0.1
+             Ix = 0.002, Iy = 0.001, Iz = 0.001, It = 0.002
              Ky = 0, Kz = 0, Sy = 0, Sz = 0
 Resolving Dirichlet boundary conditions
 	Constraining P1 V1 in direction(s) 1234

--- a/Linear/Test/Tripod.reg
+++ b/Linear/Test/Tripod.reg
@@ -48,8 +48,8 @@ Equation solver: 2
 Number of Gauss points: 1
 11. Linear Elastic Beam solver
 Problem definition:
-ElasticBeam: E = 2.1e+11, G = 8.1e+10, rho = 7850
-             A = 0.00149226, Ix = 3.37623e-06, Iy = 1.68812e-06, Iz = 1.68812e-06, It = 3.37623e-06
+ElasticBeam: E = 2.1e+11, G = 8.1e+10, rho = 7850, A = 0.00149226
+             Ix = 3.37623e-06, Iy = 1.68812e-06, Iz = 1.68812e-06, It = 3.37623e-06
              Ky = 2, Kz = 2, Sy = 0, Sz = 0
 Renumbered 2 nodes.
 Resolving Dirichlet boundary conditions

--- a/Linear/Test/Utkrager-Box.reg
+++ b/Linear/Test/Utkrager-Box.reg
@@ -1,0 +1,125 @@
+Utkrager-Box.xinp -1D -dynamic
+
+Input file: Utkrager-Box.xinp
+Equation solver: 2
+Number of Gauss points: 4
+Solution component output zero tolerance: 1e-06
+Using the linear dynamics simulation driver.
+Parsing input file Utkrager-Box.xinp
+Parsing <discretization>
+Parsing <beam>
+  Parsing <properties>
+	Box(200,100,10): A = 5600 I = 2.77867e+07 8.98667e+06 2.08864e+07 K = 3.5 1.55556
+    Constant beam properties:
+	Cross section area = 5600, moments of inertia = 3.67733e+07 2.77867e+07 8.98667e+06 2.08864e+07
+	Shear parameters = 0 0 3.5 1.55556
+  Parsing <material>
+	Stiffness moduli = 2e+08 7.69231e+07, mass density = 7.85e-06
+  Parsing <nodeload>
+	Node 5 dof 2 Load: 1e+09\*t
+Parsing <geometry>
+  Generating linear geometry on unit parameter domain \[0,1]
+	Length = 100
+  Parsing <refine>
+  Parsing <topologysets>
+	Topology sets: end1 (1,1,0D)
+  Parsing <refine>
+	Refining P1 4
+  Parsing <topologysets>
+Parsing <boundaryconditions>
+  Parsing <dirichlet>
+	Dirichlet code 123456: (fixed)
+Parsing <newmarksolver>
+	alpha1 = 0  alpha2 = 0.05
+	beta = 0.25  gamma = 0.5
+Parsing input file succeeded.
+Equation solver: 2
+Number of Gauss points: 1
+Lagrangian basis functions are used
+Problem definition:
+ElasticBeam: E = 2e+08, G = 7.69231e+07, rho = 7.85e-06, A = 5600
+             Ix = 3.67733e+07, Iy = 2.77867e+07, Iz = 8.98667e+06, It = 2.08864e+07
+             Ky = 3.5, Kz = 1.55556, Sy = 0, Sz = 0
+Newmark predictor/multicorrector: beta = 0.25 gamma = 0.5
+ using constant coefficient matrices
+ using zero acceleration predictor
+Stiffness-proportional damping (alpha2): 0.05
+11. Linear Elastic Beam solver
+Resolving Dirichlet boundary conditions
+	Constraining P1 V1 in direction(s) 123456
+ >>> SAM model summary <<<
+Number of elements    5
+Number of nodes       6
+Number of dofs        36
+Number of unknowns    30
+  step=1  time=0.01
+  Displacement L2-norm            : 0.000175308
+               Max Y-displacement : 0.000629292
+  Velocity L2-norm                : 0.0350617
+               Max Y-velocity     : 0.125858
+  Acceleration L2-norm            : 7.01234
+               Max Y-acceleration : 25.1717
+  step=2  time=0.02
+  Displacement L2-norm            : 0.000669363
+               Max Y-displacement : 0.00240276
+  Velocity L2-norm                : 0.0637491
+               Max Y-velocity     : 0.228836
+  Acceleration L2-norm            : 1.27485
+               Max Y-acceleration : 4.57623
+  step=3  time=0.03
+  Displacement L2-norm            : 0.00142421
+               Max Y-displacement : 0.00511238
+  Velocity L2-norm                : 0.0872201
+               Max Y-velocity     : 0.313087
+  Acceleration L2-norm            : 5.96903
+               Max Y-acceleration : 21.4266
+  step=4  time=0.04
+  Displacement L2-norm            : 0.00239243
+               Max Y-displacement : 0.00858793
+  Velocity L2-norm                : 0.106424
+               Max Y-velocity     : 0.382023
+  Acceleration L2-norm            : 2.12821
+               Max Y-acceleration : 7.6395
+  step=5  time=0.05
+  Displacement L2-norm            : 0.00353523
+               Max Y-displacement : 0.0126902
+  Velocity L2-norm                : 0.122136
+               Max Y-velocity     : 0.438423
+  Acceleration L2-norm            : 5.27058
+               Max Y-acceleration : 18.9194
+  step=6  time=0.06
+  Displacement L2-norm            : 0.00482087
+               Max Y-displacement : 0.0173051
+  Velocity L2-norm                : 0.134992
+               Max Y-velocity     : 0.48457
+  Acceleration L2-norm            : 2.69943
+               Max Y-acceleration : 9.68995
+  step=7  time=0.07
+  Displacement L2-norm            : 0.00622337
+               Max Y-displacement : 0.0223396
+  Velocity L2-norm                : 0.145509
+               Max Y-velocity     : 0.522325
+  Acceleration L2-norm            : 4.80297
+               Max Y-acceleration : 17.2409
+  step=8  time=0.08
+  Displacement L2-norm            : 0.0077215
+               Max Y-displacement : 0.0277173
+  Velocity L2-norm                : 0.154115
+               Max Y-velocity     : 0.553217
+  Acceleration L2-norm            : 3.08177
+               Max Y-acceleration : 11.0624
+  step=9  time=0.09
+  Displacement L2-norm            : 0.00929786
+               Max Y-displacement : 0.0333758
+  Velocity L2-norm                : 0.161156
+               Max Y-velocity     : 0.57849
+  Acceleration L2-norm            : 4.4899
+               Max Y-acceleration : 16.1171
+  step=10  time=0.1
+  Displacement L2-norm            : 0.0109382
+               Max Y-displacement : 0.0392641
+  Velocity L2-norm                : 0.166917
+               Max Y-velocity     : 0.599171
+  Acceleration L2-norm            : 3.33767
+               Max Y-acceleration : 11.981
+  Time integration completed.

--- a/Linear/Test/Utkrager-Box.xinp
+++ b/Linear/Test/Utkrager-Box.xinp
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<!-- Basic 1D elastic beam test. Cantilever beam with tip shear load. !-->
+
+<simulation>
+
+  <geometry L="100">
+    <refine patch="1" u="4"/>
+    <topologysets>
+      <set name="end1" type="vertex">
+        <item patch="1">1</item>
+      </set>
+    </topologysets>
+  </geometry>
+
+  <boundaryconditions>
+    <dirichlet set="end1" comp="123456"/>
+  </boundaryconditions>
+
+  <beam>
+    <properties B="100" H="200" t="10"/>
+    <material E="2.0e8" G="76923076.92" rho="7.85e-6"/>
+    <nodeload node="5" dof="2" type="linear">1.0e9</nodeload>
+  </beam>
+
+  <discretization type="lagrange">
+    <nGauss>1</nGauss>
+  </discretization>
+
+  <newmarksolver alpha2="0.05">
+    <nupdate>0</nupdate>
+    <timestepping>
+      <step start="0.0" end="0.1">0.01</step>
+    </timestepping>
+  </newmarksolver>
+
+</simulation>

--- a/Linear/Test/Utkrager-Pipe.reg
+++ b/Linear/Test/Utkrager-Pipe.reg
@@ -1,0 +1,125 @@
+Utkrager-Pipe.xinp -1D -dynamic
+
+Input file: Utkrager-Pipe.xinp
+Equation solver: 2
+Number of Gauss points: 4
+Solution component output zero tolerance: 1e-06
+Using the linear dynamics simulation driver.
+Parsing input file Utkrager-Pipe.xinp
+Parsing <discretization>
+Parsing <beam>
+  Parsing <properties>
+	Pipe(100,10): A = 5969.03 I = 2.70098e+07
+    Constant beam properties:
+	Cross section area = 5969.03, moments of inertia = 5.40197e+07 2.70098e+07 2.70098e+07 5.40197e+07
+	Shear parameters = 0 0 2 2
+  Parsing <material>
+	Stiffness moduli = 2e+08 7.69231e+07, mass density = 7.85e-06
+  Parsing <nodeload>
+	Node 5 dof 2 Load: 1e+09\*t
+Parsing <geometry>
+  Generating linear geometry on unit parameter domain \[0,1]
+	Length = 100
+  Parsing <refine>
+  Parsing <topologysets>
+	Topology sets: end1 (1,1,0D)
+  Parsing <refine>
+	Refining P1 4
+  Parsing <topologysets>
+Parsing <boundaryconditions>
+  Parsing <dirichlet>
+	Dirichlet code 123456: (fixed)
+Parsing <newmarksolver>
+	alpha1 = 0  alpha2 = 0.05
+	beta = 0.25  gamma = 0.5
+Parsing input file succeeded.
+Equation solver: 2
+Number of Gauss points: 1
+Lagrangian basis functions are used
+Problem definition:
+ElasticBeam: E = 2e+08, G = 7.69231e+07, rho = 7.85e-06, A = 5969.03
+             Ix = 5.40197e+07, Iy = 2.70098e+07, Iz = 2.70098e+07, It = 5.40197e+07
+             Ky = 2, Kz = 2, Sy = 0, Sz = 0
+Newmark predictor/multicorrector: beta = 0.25 gamma = 0.5
+ using constant coefficient matrices
+ using zero acceleration predictor
+Stiffness-proportional damping (alpha2): 0.05
+11. Linear Elastic Beam solver
+Resolving Dirichlet boundary conditions
+	Constraining P1 V1 in direction(s) 123456
+ >>> SAM model summary <<<
+Number of elements    5
+Number of nodes       6
+Number of dofs        36
+Number of unknowns    30
+  step=1  time=0.01
+  Displacement L2-norm            : 9.80934e-05
+               Max Y-displacement : 0.000356276
+  Velocity L2-norm                : 0.0196187
+               Max Y-velocity     : 0.0712552
+  Acceleration L2-norm            : 3.92374
+               Max Y-acceleration : 14.251
+  step=2  time=0.02
+  Displacement L2-norm            : 0.00037454
+               Max Y-displacement : 0.00136033
+  Velocity L2-norm                : 0.0356707
+               Max Y-velocity     : 0.129556
+  Acceleration L2-norm            : 0.713342
+               Max Y-acceleration : 2.59086
+  step=3  time=0.03
+  Displacement L2-norm            : 0.000796912
+               Max Y-displacement : 0.00289439
+  Velocity L2-norm                : 0.0488038
+               Max Y-velocity     : 0.177256
+  Acceleration L2-norm            : 3.33996
+               Max Y-acceleration : 12.1308
+  step=4  time=0.04
+  Displacement L2-norm            : 0.00133868
+               Max Y-displacement : 0.00486209
+  Velocity L2-norm                : 0.0595494
+               Max Y-velocity     : 0.216284
+  Acceleration L2-norm            : 1.19085
+               Max Y-acceleration : 4.32516
+  step=5  time=0.05
+  Displacement L2-norm            : 0.00197813
+               Max Y-displacement : 0.00718458
+  Velocity L2-norm                : 0.0683409
+               Max Y-velocity     : 0.248215
+  Acceleration L2-norm            : 2.94915
+               Max Y-acceleration : 10.7113
+  step=6  time=0.06
+  Displacement L2-norm            : 0.00269751
+               Max Y-displacement : 0.00979735
+  Velocity L2-norm                : 0.0755343
+               Max Y-velocity     : 0.274341
+  Acceleration L2-norm            : 1.51047
+               Max Y-acceleration : 5.48604
+  step=7  time=0.07
+  Displacement L2-norm            : 0.00348227
+               Max Y-displacement : 0.0126476
+  Velocity L2-norm                : 0.0814194
+               Max Y-velocity     : 0.295716
+  Acceleration L2-norm            : 2.68751
+               Max Y-acceleration : 9.76104
+  step=8  time=0.08
+  Displacement L2-norm            : 0.00432055
+               Max Y-displacement : 0.0156922
+  Velocity L2-norm                : 0.0862349
+               Max Y-velocity     : 0.313206
+  Acceleration L2-norm            : 1.72441
+               Max Y-acceleration : 6.26308
+  step=9  time=0.09
+  Displacement L2-norm            : 0.00520259
+               Max Y-displacement : 0.0188958
+  Velocity L2-norm                : 0.0901745
+               Max Y-velocity     : 0.327514
+  Acceleration L2-norm            : 2.51233
+               Max Y-acceleration : 9.12481
+  step=10  time=0.1
+  Displacement L2-norm            : 0.00612046
+               Max Y-displacement : 0.0222295
+  Velocity L2-norm                : 0.0933981
+               Max Y-velocity     : 0.339223
+  Acceleration L2-norm            : 1.86761
+               Max Y-acceleration : 6.78315
+  Time integration completed.

--- a/Linear/Test/Utkrager-Pipe.xinp
+++ b/Linear/Test/Utkrager-Pipe.xinp
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<!-- Basic 1D elastic beam test. Cantilever beam with tip shear load. !-->
+
+<simulation>
+
+  <geometry L="100">
+    <refine patch="1" u="4"/>
+    <topologysets>
+      <set name="end1" type="vertex">
+        <item patch="1">1</item>
+      </set>
+    </topologysets>
+  </geometry>
+
+  <boundaryconditions>
+    <dirichlet set="end1" comp="123456"/>
+  </boundaryconditions>
+
+  <beam>
+    <properties R="100" t="10"/>
+    <material E="2.0e8" G="76923076.92" rho="7.85e-6"/>
+    <nodeload node="5" dof="2" type="linear">1.0e9</nodeload>
+  </beam>
+
+  <discretization type="lagrange">
+    <nGauss>1</nGauss>
+  </discretization>
+
+  <newmarksolver alpha2="0.05">
+    <nupdate>0</nupdate>
+    <timestepping>
+      <step start="0.0" end="0.1">0.01</step>
+    </timestepping>
+  </newmarksolver>
+
+</simulation>

--- a/Linear/Test/Utkrager-dyn.reg
+++ b/Linear/Test/Utkrager-dyn.reg
@@ -33,8 +33,8 @@ Parsing input file succeeded.
 Equation solver: 2
 Number of Gauss points: 1
 Problem definition:
-ElasticBeam: E = 2.05e+11, G = 8.1e+10, rho = 7850
-             A = 0.1, Ix = 0.002, Iy = 0.001, Iz = 0.001, It = 0.002
+ElasticBeam: E = 2.05e+11, G = 8.1e+10, rho = 7850, A = 0.1
+             Ix = 0.002, Iy = 0.001, Iz = 0.001, It = 0.002
              Ky = 1.2, Kz = 1.2, Sy = 0, Sz = 0
 Newmark predictor/multicorrector: beta = 0.25 gamma = 0.5
  using constant coefficient matrices

--- a/Linear/Test/Utkrager.reg
+++ b/Linear/Test/Utkrager.reg
@@ -32,8 +32,8 @@ Equation solver: 2
 Number of Gauss points: 1
 11. Linear Elastic Beam solver
 Problem definition:
-ElasticBeam: E = 2.05e+11, G = 8.1e+10, rho = 7850
-             A = 0.1, Ix = 0.002, Iy = 0.001, Iz = 0.001, It = 0.002
+ElasticBeam: E = 2.05e+11, G = 8.1e+10, rho = 7850, A = 0.1
+             Ix = 0.002, Iy = 0.001, Iz = 0.001, It = 0.002
              Ky = 1.2, Kz = 1.2, Sy = 0, Sz = 0
 Resolving Dirichlet boundary conditions
 	Constraining P1 V1 in direction(s) 123456

--- a/Linear/Test/boatbeam.reg
+++ b/Linear/Test/boatbeam.reg
@@ -51,8 +51,8 @@ Equation solver: 2
 Number of Gauss points: 1
 11. Linear Elastic Beam solver
 Problem definition:
-ElasticBeam: E = 2.05e+11, G = 7.94e+10, rho = 7850
-             A = 0.1, Ix = 0.002, Iy = 0.001, Iz = 0.001, It = 0.002
+ElasticBeam: E = 2.05e+11, G = 7.94e+10, rho = 7850, A = 0.1
+             Ix = 0.002, Iy = 0.001, Iz = 0.001, It = 0.002
              Ky = 0, Kz = 0, Sy = 0, Sz = 0
 Resolving Dirichlet boundary conditions
 	Constraining P1 V1 in direction(s) 1234


### PR DESCRIPTION
Fixed: Shear reduction factors for hollow Pipe-sections.
Changed: Print cross section area on separate line before the inertias, and also print rotation angle phi and the eccentricities, if non-zero. Move output stream operator out of class scope since members are public.