### PR TITLE
Store evaluation time for secondary solution

### DIFF
--- a/Elasticity.C
+++ b/Elasticity.C
@@ -313,9 +313,11 @@ void Elasticity::initIntegration (size_t, size_t nBp)
 }
 
 
-void Elasticity::initResultPoints (double, bool prinDir)
+void Elasticity::initResultPoints (double time, char prinDir)
 {
-  if (wantPrincipalStress && prinDir)
+  myTime = time;
+
+  if (wantPrincipalStress && prinDir > 0)
   {
     if (!pDirBuf) pDirBuf = new Vec3Vec();
     pDirBuf->clear();
@@ -1018,7 +1020,7 @@ void Elasticity::printMaxVals (std::streamsize precision, size_t comp) const
       continue; // no value
 
     std::string name = this->getField2Name(i,nullptr);
-    os <<"  Max "<< name <<":";
+    os <<"  Max "<< name.substr(0,16) <<":";
     if (name.size() < 16)
       os << std::string(16-name.size(),' ');
     for (size_t p = 0; p < maxVal[i].size(); p++)

--- a/Elasticity.h
+++ b/Elasticity.h
@@ -90,9 +90,9 @@ public:
   virtual void initIntegration(size_t nGp, size_t nBp);
 
   //! \brief Initializes the integrand for a new result point loop.
-  //! \param[in] lambda Load parameter
-  //! \param[in] prinDirs If \e true, compute/store principal directions
-  virtual void initResultPoints(double lambda, bool prinDirs);
+  //! \param[in] time Current time
+  //! \param[in] prinDirs If &gt; 0, compute/store principal directions
+  virtual void initResultPoints(double time, char prinDirs);
 
   using ElasticBase::getLocalIntegral;
   //! \brief Returns a local integral container for the given element.
@@ -223,8 +223,9 @@ public:
   //! to calculate the maximum stress values in the model. If the argument \a nP
   //! is equal to 1, only the global maxima over all patches in the model are
   //! determined. Otherwise, if it equals the number of patches in the model,
-  //! the maximum values are computed for each patch separately.
-  void initMaxVals(size_t nP = 1);
+  //! the maximum values are computed for each patch separately. If \a nP is 0,
+  //! the max-values buffer is initialized to zero without touching its size.
+  void initMaxVals(size_t nP = 0);
 
   //! \brief Returns a pointer to the max values for external update.
   std::vector<PointValues>* getMaxVals() const { return &maxVal; }

--- a/NonlinearDriver.C
+++ b/NonlinearDriver.C
@@ -241,6 +241,8 @@ int NonlinearDriver::solveProblem (DataExporter* writer, HDF5Restart* restart,
     getMaxVals = printMax = false;
   else if (doProject)
     getMaxVals = true;
+  if (getMaxVals && !printMax)
+    const_cast<Elasticity*>(elp)->initMaxVals(1);
 
   int iStep = aStep = 0; // Save initial state to VTF
   if (save0 && opt.format >= 0 && params.multiSteps() && params.time.dt > 0.0)


### PR DESCRIPTION
Fixed: Let the default value of the nP argument be zero, implying reinitialization of the max value buffer.
Changed: char as type on the prinDir argument.

Downstreams of OPM/IFEM#852