### PR TITLE
Avoid specifying material properties in analytical solutions

### DIFF
--- a/Elasticity/KirchhoffLove.C
+++ b/Elasticity/KirchhoffLove.C
@@ -169,6 +169,12 @@ void KirchhoffLove::setThickness (RealFunc* tf)
 }
 
 
+double KirchhoffLove::getThickness (const Vec3& X) const
+{
+  return (*thickness)(X);
+}
+
+
 void KirchhoffLove::setPressure (RealFunc* pf)
 {
   if (pf)
@@ -278,7 +284,7 @@ Vec3 KirchhoffLove::getPressure (const Vec3& X, const Vec3& n, bool grd) const
 {
   Vec3 p;
   if (!grd)
-    p.z = material->getMassDensity(X) * gravity * (*thickness)(X);
+    p.z = material->getMassDensity(X) * gravity * this->getThickness(X);
 
   for (RealFunc* pf : presFld)
     if (n.isZero()) // Assume pressure acts in global Z-direction
@@ -352,7 +358,7 @@ void KirchhoffLove::formBodyForce (Vector& ES, RealArray& sumLoad,
 void KirchhoffLove::formMassMatrix (Matrix& EM, const Vector& N,
                                     const Vec3& X, double detJW) const
 {
-  double rhow = material->getMassDensity(X) * (*thickness)(X) * detJW;
+  double rhow = material->getMassDensity(X) * this->getThickness(X) * detJW;
   if (rhow == 0.0) return;
 
   if (npv == 1)

--- a/Elasticity/KirchhoffLove.h
+++ b/Elasticity/KirchhoffLove.h
@@ -71,8 +71,12 @@ public:
   void setThickness(double t);
   //! \brief Defines the plate/shell thickness as a function.
   void setThickness(RealFunc* tf = nullptr);
+  //! \brief Returns the plate/shell thickness at specified point.
+  double getThickness(const Vec3& X) const;
   //! \brief Defines the material properties.
   void setMaterial(Material* mat) { material = mat; }
+  //! \brief Returns the current material object.
+  Material* getMaterial() const { return material; }
   //! \brief Defines the pressure field.
   void setPressure(RealFunc* pf = nullptr);
   //! \brief Defines the line load function.

--- a/Elasticity/LinIsotropic.C
+++ b/Elasticity/LinIsotropic.C
@@ -364,6 +364,12 @@ double LinIsotropic::getPlateStiffness (const Vec3& X,
 }
 
 
+double LinIsotropic::getPoissonRatio (const Vec3& X) const
+{
+  return nuFunc ? (*nuFunc)(X) : nu;
+}
+
+
 double LinIsotropic::getMassDensity (const Vec3& X) const
 {
   return rhoFunc ? (*rhoFunc)(X) : rho;

--- a/Elasticity/LinIsotropic.C
+++ b/Elasticity/LinIsotropic.C
@@ -98,7 +98,9 @@ void LinIsotropic::parse (const tinyxml2::XMLElement* elem)
     utl::getAttribute(child,"type",type,true);
     IFEM::cout <<"\n\t  "<< name <<" function ("<< type <<") ";
     const tinyxml2::XMLNode* aval = child->FirstChild();
-    return aval ? utl::parseRealFunc(aval->Value(),type) : nullptr;
+    RealFunc* f = aval ? utl::parseRealFunc(aval->Value(),type) : nullptr;
+    IFEM::cout << std::endl;
+    return f;
   };
 
   // Lambda function for parsing a scalar property function.
@@ -146,7 +148,9 @@ void LinIsotropic::parse (const tinyxml2::XMLElement* elem)
       str <<"  cp="<< heatcapacity;
     if (!condFunc && elem->Attribute("kappa"))
       str <<"  kappa="<< conductivity;
-    if (!str.str().empty())
+    if (str.str().empty())
+      IFEM::cout <<"\t(no constant material parameters)";
+    else
       IFEM::cout <<"\t"<< str.str();
   }
 }

--- a/Elasticity/LinIsotropic.h
+++ b/Elasticity/LinIsotropic.h
@@ -76,8 +76,10 @@ public:
   virtual double getStiffness(const Vec3& X, double age) const;
   //! \brief Evaluates the plate stiffness parameter at current point.
   virtual double getPlateStiffness(const Vec3& X, double t, double age) const;
+  //! \brief Evaluates the Poisson's ratio at current point.
+  virtual double getPoissonRatio(const Vec3& X) const;
   //! \brief Evaluates the mass density at current point.
-  virtual double getMassDensity(const Vec3&) const;
+  virtual double getMassDensity(const Vec3& X) const;
   //! \brief Evaluates the heat capacity for given temperature.
   virtual double getHeatCapacity(double T) const;
   //! \brief Evaluates the thermal conductivity for given temperature.

--- a/Elasticity/MaterialBase.h
+++ b/Elasticity/MaterialBase.h
@@ -64,14 +64,16 @@ public:
   //! \brief Evaluates the plate stiffness parameter at current point.
   virtual double getPlateStiffness(const Vec3&,
                                    double, double = 0.0) const { return 0.0; }
+  //! \brief Evaluates the Poisson's ratio at current point.
+  virtual double getPoissonRatio(const Vec3&) const { return 0.0; }
   //! \brief Evaluates the mass density at current point.
   virtual double getMassDensity(const Vec3&) const { return 0.0; }
   //! \brief Evaluates the heat capacity for given temperature.
-  virtual double getHeatCapacity(double) const { return 1.0; }
+  virtual double getHeatCapacity(double = 0.0) const { return 1.0; }
   //! \brief Evaluates the thermal conductivity for given temperature.
-  virtual double getThermalConductivity(double) const { return 1.0; }
+  virtual double getThermalConductivity(double = 0.0) const { return 1.0; }
   //! \brief Evaluates the thermal expansion coefficient for given temperature.
-  virtual double getThermalExpansion(double) const { return 0.0; }
+  virtual double getThermalExpansion(double = 0.0) const { return 0.0; }
 
   //! \brief Evaluates the constitutive relation at an integration point.
   //! \param[out] C Constitutive matrix at current point

--- a/Linear/SIMLinEl.h
+++ b/Linear/SIMLinEl.h
@@ -291,24 +291,19 @@ protected:
 
     // Check for static condensation
     const tinyxml2::XMLElement* sctag = nullptr;
-    const tinyxml2::XMLElement* child = elem->FirstChildElement();
     if (!strcasecmp(elem->Value(),SIMElasticity<Dim>::myContext.c_str()))
-      for (; child; child = child->NextSiblingElement())
-      {
+      for (const tinyxml2::XMLElement* child = elem->FirstChildElement();
+           child; child = child->NextSiblingElement())
         if (!strcasecmp(child->Value(),"staticCondensation"))
           sctag = child; // Delay parsing until the FE data have been parsed
         else if (!strcasecmp(child->Value(),"superelement"))
-        {
-          std::string sId;
-          if (utl::getAttribute(child,"id",sId))
-          if (!supSC.empty() && sId != supSC)
-          {
-            // Ignore superelements not specified for static condensation
-            IFEM::cout <<"\tIgnoring superelement \""<< sId <<"\""<< std::endl;
-            return true;
-          }
-        }
-      }
+          if (std::string id; utl::getAttribute(child,"id",id))
+            if (!supSC.empty() && id != supSC)
+            {
+              // Ignore superelements not specified for static condensation
+              IFEM::cout <<"\tIgnoring superelement \""<< id <<"\""<< std::endl;
+              return true;
+            }
 
     if (!this->SIMElasticity<Dim>::parse(elem))
       return false;

--- a/Linear/SIMLinEl2D.C
+++ b/Linear/SIMLinEl2D.C
@@ -13,6 +13,7 @@
 
 #include "SIMLinEl.h"
 #include "AnalyticSolutions.h"
+#include "MaterialBase.h"
 
 
 template<> bool SIMLinEl2D::parseDimSpecific (char* cline)
@@ -21,7 +22,7 @@ template<> bool SIMLinEl2D::parseDimSpecific (char* cline)
   {
     double a  = atof(strtok(nullptr," "));
     double F0 = atof(strtok(nullptr," "));
-    double nu = atof(strtok(nullptr," "));
+    double nu = this->getIntegrand()->getMaterial()->getPoissonRatio(Vec3());
     IFEM::cout <<"\nAnalytical solution: Hole a="<< a <<" F0="<< F0
                <<" nu="<< nu << std::endl;
     if (!mySol)
@@ -31,7 +32,7 @@ template<> bool SIMLinEl2D::parseDimSpecific (char* cline)
   {
     double a  = atof(strtok(nullptr," "));
     double F0 = atof(strtok(nullptr," "));
-    double nu = atof(strtok(nullptr," "));
+    double nu = this->getIntegrand()->getMaterial()->getPoissonRatio(Vec3());
     IFEM::cout <<"\nAnalytical solution: Lshape a="<< a <<" F0="<< F0
                <<" nu="<< nu << std::endl;
     if (!mySol)
@@ -61,7 +62,7 @@ template<> bool SIMLinEl2D::parseDimSpecific (char* cline)
     double a  = atof(strtok(nullptr," "));
     double b  = atof(strtok(nullptr," "));
     double u0 = atof(strtok(nullptr," "));
-    double E  = atof(strtok(nullptr," "));
+    double E  = this->getIntegrand()->getMaterial()->getStiffness(Vec3());
     IFEM::cout <<"\nAnalytical solution: Curved Beam a="<< a <<" b="<< b
                <<" u0="<< u0 <<" E="<< E << std::endl;
     if (!mySol)
@@ -79,10 +80,10 @@ template<> bool SIMLinEl2D::parseDimSpecific (const tinyxml2::XMLElement* child,
 {
   if (type == "hole")
   {
-    double a = 0.0, F0 = 0.0, nu = 0.0;
+    double a = 0.0, F0 = 0.0;
     utl::getAttribute(child,"a",a);
     utl::getAttribute(child,"F0",F0);
-    utl::getAttribute(child,"nu",nu);
+    double nu = this->getIntegrand()->getMaterial()->getPoissonRatio(Vec3());
     IFEM::cout <<"\tAnalytical solution: Hole a="<< a <<" F0="<< F0
                <<" nu="<< nu << std::endl;
     if (!mySol)
@@ -90,10 +91,10 @@ template<> bool SIMLinEl2D::parseDimSpecific (const tinyxml2::XMLElement* child,
   }
   else if (type == "lshape")
   {
-    double a = 0.0, F0 = 0.0, nu = 0.0;
+    double a = 0.0, F0 = 0.0;
     utl::getAttribute(child,"a",a);
     utl::getAttribute(child,"F0",F0);
-    utl::getAttribute(child,"nu",nu);
+    double nu = this->getIntegrand()->getMaterial()->getPoissonRatio(Vec3());
     IFEM::cout <<"\tAnalytical solution: Lshape a="<< a <<" F0="<< F0
                <<" nu="<< nu << std::endl;
     if (!mySol)
@@ -123,11 +124,11 @@ template<> bool SIMLinEl2D::parseDimSpecific (const tinyxml2::XMLElement* child,
   }
   else if (type == "curved")
   {
-    double a = 0.0, b = 0.0, u0 = 0.0, E = 0.0;
+    double a = 0.0, b = 0.0, u0 = 0.0;
     utl::getAttribute(child,"a",a);
     utl::getAttribute(child,"b",b);
     utl::getAttribute(child,"u0",u0);
-    utl::getAttribute(child,"E",E);
+    double E = this->getIntegrand()->getMaterial()->getStiffness(Vec3());
     IFEM::cout <<"\tAnalytical solution: Curved Beam a="<< a <<" b="<< b
                <<" u0="<< u0 <<" E="<< E << std::endl;
     if (!mySol)
@@ -136,19 +137,18 @@ template<> bool SIMLinEl2D::parseDimSpecific (const tinyxml2::XMLElement* child,
   else if (type == "pipe")
   {
     double Ri = 0.0, Ro = 0.0, Ti = 0.0, To = 0.0, T0 = 273.0;
-    double E = 0.0, nu = 0.0, alpha = 0.0;
     bool polar = false;
     utl::getAttribute(child,"Ri",Ri);
     utl::getAttribute(child,"Ro",Ro);
     utl::getAttribute(child,"Ti",Ti);
     utl::getAttribute(child,"To",To);
     utl::getAttribute(child,"Tref",T0);
-    utl::getAttribute(child,"E",E);
-    utl::getAttribute(child,"nu",nu);
-    utl::getAttribute(child,"alpha",alpha);
     utl::getAttribute(child,"polar",polar);
+    double E = this->getIntegrand()->getMaterial()->getStiffness(Vec3());
+    double nu = this->getIntegrand()->getMaterial()->getPoissonRatio(Vec3());
+    double alpha = this->getIntegrand()->getMaterial()->getThermalExpansion();
     IFEM::cout <<"\tAnalytical solution: Pipe Ri="<< Ri <<" Ro="<< Ro
-               <<" Ti="<< Ti <<" To="<< To << std::endl;
+               <<" Ti="<< Ti <<" To="<< To <<" Tref="<< T0 << std::endl;
     if (!mySol)
       mySol = new AnaSol(new Pipe(Ri,Ro,Ti,To,T0,E,nu,alpha,false,polar));
   }

--- a/Linear/SIMLinEl3D.C
+++ b/Linear/SIMLinEl3D.C
@@ -13,6 +13,7 @@
 
 #include "SIMLinEl.h"
 #include "AnalyticSolutions.h"
+#include "MaterialBase.h"
 
 
 template<> bool SIMLinEl3D::parseDimSpecific (char* cline)
@@ -21,7 +22,7 @@ template<> bool SIMLinEl3D::parseDimSpecific (char* cline)
   {
     double a  = atof(strtok(nullptr," "));
     double F0 = atof(strtok(nullptr," "));
-    double nu = atof(strtok(nullptr," "));
+    double nu = this->getIntegrand()->getMaterial()->getPoissonRatio(Vec3());
     IFEM::cout <<"\nAnalytical solution: Hole a="<< a <<" F0="<< F0
                <<" nu="<< nu << std::endl;
     if (!mySol)
@@ -31,7 +32,7 @@ template<> bool SIMLinEl3D::parseDimSpecific (char* cline)
   {
     double a  = atof(strtok(nullptr," "));
     double F0 = atof(strtok(nullptr," "));
-    double nu = atof(strtok(nullptr," "));
+    double nu = this->getIntegrand()->getMaterial()->getPoissonRatio(Vec3());
     IFEM::cout <<"\nAnalytical solution: Lshape a="<< a <<" F0="<< F0
                <<" nu="<< nu << std::endl;
     if (!mySol)
@@ -59,10 +60,10 @@ template<> bool SIMLinEl3D::parseDimSpecific (const tinyxml2::XMLElement* child,
 {
   if (type == "hole")
   {
-    double a = 0.0, F0 = 0.0, nu = 0.0;
+    double a = 0.0, F0 = 0.0;
     utl::getAttribute(child,"a",a);
     utl::getAttribute(child,"F0",F0);
-    utl::getAttribute(child,"nu",nu);
+    double nu = this->getIntegrand()->getMaterial()->getPoissonRatio(Vec3());
     IFEM::cout <<"\tAnalytical solution: Hole a="<< a <<" F0="<< F0
                <<" nu="<< nu << std::endl;
     if (!mySol)
@@ -70,10 +71,10 @@ template<> bool SIMLinEl3D::parseDimSpecific (const tinyxml2::XMLElement* child,
   }
   else if (type == "lshape")
   {
-    double a = 0.0, F0 = 0.0, nu = 0.0;
+    double a = 0.0, F0 = 0.0;
     utl::getAttribute(child,"a",a);
     utl::getAttribute(child,"F0",F0);
-    utl::getAttribute(child,"nu",nu);
+    double nu = this->getIntegrand()->getMaterial()->getPoissonRatio(Vec3());
     IFEM::cout <<"\tAnalytical solution: Lshape a="<< a <<" F0="<< F0
                <<" nu="<< nu << std::endl;
     if (!mySol)
@@ -93,19 +94,18 @@ template<> bool SIMLinEl3D::parseDimSpecific (const tinyxml2::XMLElement* child,
   else if (type == "pipe")
   {
     double Ri = 0.0, Ro = 0.0, Ti = 0.0, To = 0.0, T0 = 273.0;
-    double E = 0.0, nu = 0.0, alpha = 0.0;
     bool polar = false;
     utl::getAttribute(child,"Ri",Ri);
     utl::getAttribute(child,"Ro",Ro);
     utl::getAttribute(child,"Ti",Ti);
     utl::getAttribute(child,"To",To);
     utl::getAttribute(child,"Tref",T0);
-    utl::getAttribute(child,"E",E);
-    utl::getAttribute(child,"nu",nu);
-    utl::getAttribute(child,"alpha",alpha);
     utl::getAttribute(child,"polar",polar);
+    double E = this->getIntegrand()->getMaterial()->getStiffness(Vec3());
+    double nu = this->getIntegrand()->getMaterial()->getPoissonRatio(Vec3());
+    double alpha = this->getIntegrand()->getMaterial()->getThermalExpansion();
     IFEM::cout <<"\tAnalytical solution: Pipe Ri="<< Ri <<" Ro="<< Ro
-               <<" Ti="<< Ti <<" To="<< To << std::endl;
+               <<" Ti="<< Ti <<" To="<< To <<" Tref="<< T0 << std::endl;
     if (!mySol)
       mySol = new AnaSol(new Pipe(Ri,Ro,Ti,To,T0,E,nu,alpha,true,polar));
   }

--- a/Linear/SIMLinElKL.C
+++ b/Linear/SIMLinElKL.C
@@ -14,6 +14,7 @@
 #include "SIMLinElKL.h"
 #include "KirchhoffLovePlate.h"
 #include "KirchhoffLoveShell.h"
+#include "MaterialBase.h"
 #include "AnalyticSolutions.h"
 #include "AnaSol.h"
 #include "IFEM.h"
@@ -43,10 +44,10 @@ bool SIMLinElKL::parseAnaSol (char* keyWord, std::istream& is)
   {
     double a  = atof(strtok(nullptr," "));
     double b  = atof(strtok(nullptr," "));
-    double t  = atof(strtok(nullptr," "));
-    double E  = atof(strtok(nullptr," "));
-    double nu = atof(strtok(nullptr," "));
     double pz = atof(strtok(nullptr," "));
+    double t  = this->getProblem()->getThickness(Vec3());
+    double E  = this->getProblem()->getMaterial()->getStiffness(Vec3());
+    double nu = this->getProblem()->getMaterial()->getPoissonRatio(Vec3());
     IFEM::cout <<"\nAnalytic solution: NavierPlate a="<< a <<" b="<< b
                <<" t="<< t <<" E="<< E <<" nu="<< nu <<" pz="<< pz;
     if ((cline = strtok(nullptr," ")))
@@ -89,20 +90,19 @@ bool SIMLinElKL::parseAnaSol (const tinyxml2::XMLElement* elem)
   utl::getAttribute(elem,"type",type,true);
   if (type == "navierplate")
   {
-    double a = 0.0, b = 0.0, c = 0.0, d = 0.0, t = 0.0;
-    double E = 10000.0, nu = 0.3, pz = 1.0, xi = 0.0, eta = 0.0;
+    double a = 0.0, b = 0.0, c = 0.0, d = 0.0, pz = 1.0, xi = 0.0, eta = 0.0;
     int max_mn = 100;
     utl::getAttribute(elem,"a",a);
     utl::getAttribute(elem,"b",b);
     utl::getAttribute(elem,"c",c);
     utl::getAttribute(elem,"d",d);
-    utl::getAttribute(elem,"t",t);
-    utl::getAttribute(elem,"E",E);
-    utl::getAttribute(elem,"nu",nu);
     utl::getAttribute(elem,"pz",pz);
     utl::getAttribute(elem,"xi",xi);
     utl::getAttribute(elem,"eta",eta);
     utl::getAttribute(elem,"nTerm",max_mn);
+    double t  = this->getProblem()->getThickness(Vec3());
+    double E  = this->getProblem()->getMaterial()->getStiffness(Vec3());
+    double nu = this->getProblem()->getMaterial()->getPoissonRatio(Vec3());
     IFEM::cout <<"\tAnalytic solution: NavierPlate a="<< a <<" b="<< b
                <<" t="<< t <<" E="<< E <<" nu="<< nu <<" pz="<< pz;
     if (xi != 0.0 && eta != 0.0)
@@ -122,12 +122,12 @@ bool SIMLinElKL::parseAnaSol (const tinyxml2::XMLElement* elem)
   }
   else if (type == "circularplate")
   {
-    double R = 0.0, t = 0.0, E = 10000.0, nu = 0.3, P = 1000000.0;
+    double R = 0.0, P = 1000000.0;
     utl::getAttribute(elem,"R",R);
-    utl::getAttribute(elem,"t",t);
-    utl::getAttribute(elem,"E",E);
-    utl::getAttribute(elem,"nu",nu);
     utl::getAttribute(elem,"P",P);
+    double t  = this->getProblem()->getThickness(Vec3());
+    double E  = this->getProblem()->getMaterial()->getStiffness(Vec3());
+    double nu = this->getProblem()->getMaterial()->getPoissonRatio(Vec3());
     IFEM::cout <<"\tAnalytic solution: CircularPlate R="<< R <<" t="<< t
                <<" E="<< E <<" nu="<< nu <<" P="<< P << std::endl;
     if (!mySol)

--- a/Test/Linear/AnnulusWithTemp2D.xinp
+++ b/Test/Linear/AnnulusWithTemp2D.xinp
@@ -27,9 +27,7 @@
       r=sqrt(x*x+y*y); a=0.03; b=0.04; Ti=373.0; To=293.0;
       Ti+(To-Ti)*log(r/a)/log(b/a)
     </temperature>
-    <anasol type="pipe"
-            Ri="0.03" Ro="0.04" Ti="373.0" To="293.0" Tref="273.0"
-            E="2.0e11" nu="0.3" alpha="1.2e-5"/>
+    <anasol type="pipe" Ri="0.03" Ro="0.04" Ti="373.0" To="293.0" Tref="273.0"/>
   </elasticity>
 
 </simulation>

--- a/Test/Linear/Hole2D-p3.inp
+++ b/Test/Linear/Hole2D-p3.inp
@@ -15,14 +15,14 @@ CONSTRAINTS 2
   1     1    1
   1     2    2
 
+ISOTROPIC 1
+# code E      nu  rho
+  0    1000.0 0.3 0.0
+
 # Analytical solution
-# Specifier a   F0   nu
-ANASOL Hole 1.0 10.0 0.3
+# Specifier a   F0
+ANASOL Hole 1.0 10.0
 
 PRESSURE 1
 # patch edge
   1     4
-
-ISOTROPIC 1
-# code E      nu  rho
-  0    1000.0 0.3 0.0

--- a/Test/Linear/NavierPart_p2.inp
+++ b/Test/Linear/NavierPart_p2.inp
@@ -24,8 +24,8 @@ PRESSURE 1
   0    1.0e3 StepXY 4.0 3.2 to 6.0 4.8
 
 # Analytical solution
-# Specifier        a    b   t   E      nu  pz    xi  eta c   d
-ANASOL NavierPlate 10.0 8.0 0.1 2.1e11 0.3 1.0e3 0.5 0.5 2.0 1.6
+# Specifier        a    b   pz    xi  eta c   d
+ANASOL NavierPlate 10.0 8.0 1.0e3 0.5 0.5 2.0 1.6
 
 RESULTPOINTS 1
 # patch xi eta

--- a/Test/Linear/NavierPart_p3.inp
+++ b/Test/Linear/NavierPart_p3.inp
@@ -28,8 +28,8 @@ PRESSURE 1
   0    1.0e3 StepXY 4.0 3.2 to 6.0 4.8
 
 # Analytical solution
-# Specifier        a    b   t   E      nu  pz    xi  eta c   d
-ANASOL NavierPlate 10.0 8.0 0.1 2.1e11 0.3 1.0e3 0.5 0.5 2.0 1.6
+# Specifier        a    b   pz    xi  eta c   d
+ANASOL NavierPlate 10.0 8.0 1.0e3 0.5 0.5 2.0 1.6
 
 RESULTPOINTS 1
 # patch xi eta

--- a/Test/Linear/NavierPoint_p3.inp
+++ b/Test/Linear/NavierPoint_p3.inp
@@ -28,8 +28,8 @@ POINTLOAD 1
   1     0.5 0.5 1.0e3
 
 # Analytical solution
-# Specifier        a    b   t   E      nu  pz    xi  eta
-ANASOL NavierPlate 10.0 8.0 0.1 2.1e11 0.3 1.0e3 0.5 0.5
+# Specifier        a    b   pz    xi  eta
+ANASOL NavierPlate 10.0 8.0 1.0e3 0.5 0.5
 
 RESULTPOINTS 1
 # patch xi eta

--- a/Test/Linear/SquarePoint-varying.reg
+++ b/Test/Linear/SquarePoint-varying.reg
@@ -30,9 +30,6 @@ Parsing <kirchhofflove>
 	  nu=0.3
 	  Thickness function (expression) : 0.1+0.01\*x\*y
 	Point: P1 xi = 0.5 0.5 load = 10000
-	Analytic solution: NavierPlate a=10 b=10 t=0.1 E=2.1e+11 nu=0.3 pz=10000 xi=0.5 eta=0.5
-NavierPlate: w_centre = 0.0006032093628
-             Max. number of terms in Fourier series = 100
 Parsing <postprocessing>
   Parsing <resultpoints>
 	Point 1: P1 xi = 0.5 0.5
@@ -56,6 +53,8 @@ Result point #1: patch #1 (u,v)=(0.5,0.5), node #25, X = 5 5 0
 Result point #2: patch #1 (u,v)=(0.5,0.25), node #18, X = 5 2.5 0
 Result point #3: patch #1 (u,v)=(0.25,0.5), node #24, X = 2.5 5 0
 Result point #4: patch #1 (u,v)=(0.25,0.25), node #17, X = 2.5 2.5 0
+Primary solution components (sol1): "w"
+Secondary solution components (sol2): "m_xx" "m_yy" "m_xy" "q_x" "q_y"
  >>> SAM model summary <<<
 Number of elements    16
 Number of nodes       49
@@ -75,24 +74,11 @@ Max displacement   : 2.00952e-05
 Integrating solution norms (FE solution) ...
 Energy norm |u^h| = a(u^h,u^h)^0.5   : 0.371332
 External energy ((f,u^h)+(t,u^h)^0.5 : 0.371332
-Exact norm  |u|   = a(u,u)^0.5       : 0.770595
-Exact error a(e,e)^0.5, e=u-u^h      : 0.675135
-Exact relative error (%) : 87.6122
-Residual error (r(u) + J(u))^0.5 : 224292
- relative error (% of |u|) : 2.91064e+07
   Node #25:	sol1 =  1.378878e-05
-		exact1  6.032094e-04
 		sol2 =  1.782452e+03  1.782452e+03 -2.492849e+02 -1.119306e+03 -1.119306e+03
-		exact2  5.303541e+03  5.303541e+03  0.000000e+00
   Node #18:	sol1 =  1.454498e-05
-		exact1  3.712398e-04
 		sol2 =  3.213670e+02  4.040589e+02  5.481737e+01 -1.817750e+02 -7.198235e+01
-		exact2  9.868972e+02  5.946594e+02  0.000000e+00
   Node #24:	sol1 =  1.454498e-05
-		exact1  3.712398e-04
 		sol2 =  4.040589e+02  3.213670e+02  5.481737e+01 -7.198235e+01 -1.817750e+02
-		exact2  5.946594e+02  9.868972e+02  0.000000e+00
   Node #17:	sol1 =  1.400533e-05
-		exact1  2.479190e-04
 		sol2 =  3.012065e+02  3.012065e+02 -8.336491e+00  1.561390e+01  1.561390e+01
-		exact2  4.558936e+02  4.558936e+02 -4.310359e+02

--- a/Test/Linear/SquarePoint-varying.xinp
+++ b/Test/Linear/SquarePoint-varying.xinp
@@ -2,7 +2,7 @@
 
 <!-- Simply supported square plate with central point load.
      Cubic spline Kirchhoff-Love thin plate elements.
-     Varying plat thickness and material properties. -->
+     Varying plate thickness and material properties. -->
 
 <simulation>
 
@@ -26,9 +26,6 @@
       <thickness type="expression">0.1+0.01*x*y</thickness>
     </isotropic>
     <pointload patch="1" xi="0.5" eta="0.5" onElement="true">10000.0</pointload>
-    <anasol type="NavierPlate"
-            a="10.0" b="10.0" t="0.1" E="2.1e11" nu="0.3"
-            xi="0.5" eta="0.5" pz="10000.0"/>
   </kirchhofflove>
 
   <postprocessing>


### PR DESCRIPTION
Instead, use data from the Material property object.