### PR TITLE
Delay writing geometry to VTF until reading serialized data in restarts

### DIFF
--- a/Elasticity/NewmarkDriver.h
+++ b/Elasticity/NewmarkDriver.h
@@ -101,6 +101,14 @@ public:
 
     double nextSave = params.time.t + Newmark::opt.dtSave;
 
+    if (Newmark::opt.format >= 0)
+    {
+      PROFILE("Postprocessing");
+      // Save geometry to VTF
+      if (!this->saveModel(params.time.t))
+        return 4;
+    }
+
     // Open output file for result point print, if requested
     std::ostream* os = !rptFile.empty() ? new std::ofstream(rptFile) : nullptr;
     utl::LogStream* log = os ? new utl::LogStream(*os) : &IFEM::cout;

--- a/Elasticity/NonlinearDriver.C
+++ b/Elasticity/NonlinearDriver.C
@@ -248,12 +248,16 @@ int NonlinearDriver::solveProblem (DataExporter* writer, HDF5Restart* restart,
   if (getMaxVals && !printMax)
     printMax = const_cast<Elasticity*>(elp)->initMaxVals(1);
 
-  int iStep = aStep = 0; // Save initial state to VTF
-  if (save0 && opt.format >= 0 && params.multiSteps() && params.time.dt > 0.0)
+  int iStep = aStep = 0;
+  if (opt.format >= 0)
   {
     PROFILE("Postprocessing");
-    if (!this->saveStep(-(++iStep),params.time.t))
+    // Save geometry and (optionally) the initial state to VTF
+    if (!this->saveModel(params.time.t))
       return 4;
+    if (save0 && params.multiSteps() && params.time.dt > 0.0)
+      if (!this->saveStep(-(++iStep),params.time.t))
+        return 4;
   }
 
   // Initialize mesh adaptation parameters

--- a/Elasticity/SIMElasticity.C
+++ b/Elasticity/SIMElasticity.C
@@ -878,10 +878,9 @@ void SIMElasticity<Dim>::printNormGroup (const Vector& gNorm,
 */
 
 template<class Dim>
-bool SIMElasticity<Dim>::writeGlvG (int& nBlock,
-                                    const char* inpFile, bool doClear)
+bool SIMElasticity<Dim>::writeGlvG (int& nBlock, double time, bool append)
 {
-  if (!this->Dim::writeGlvG(nBlock,inpFile,doClear))
+  if (!this->Dim::writeGlvG(nBlock,time,append))
     return false;
   else if (!plotRgd)
     return true;

--- a/Elasticity/SIMElasticity.h
+++ b/Elasticity/SIMElasticity.h
@@ -151,11 +151,12 @@ public:
   //! \param weights Nodal weights (in case some nodes are present in more sets)
   virtual void printIFforces(const Vector& sf, RealArray& weights);
 
+  using Dim::writeGlvG;
   //! \brief Writes current model geometry to the VTF-file.
   //! \param nBlock Running result block counter
-  //! \param[in] inpFile File name used to construct the VTF-file name from
-  //! \param[in] doClear If \e true, clear geometry block if \a inpFile is null
-  virtual bool writeGlvG(int& nBlock, const char* inpFile, bool doClear = true);
+  //! \param[in] time The time from which this (new) geometry applies
+  //! \param[in] append If \e true, append new blocks to existing ones, if any
+  virtual bool writeGlvG(int& nBlock, double time, bool append);
 
 protected:
   MaterialVec mVec;         //!< Material data

--- a/FiniteDeformation/SIMFiniteDefEl.C
+++ b/FiniteDeformation/SIMFiniteDefEl.C
@@ -387,9 +387,9 @@ void SIMFiniteDefEl<Dim>::printIFforces (const Vector& sf, RealArray& weights)
 
 
 template<class Dim>
-bool SIMFiniteDefEl<Dim>::writeGlvG (int& nBlock, const char* inpFile, bool)
+bool SIMFiniteDefEl<Dim>::writeGlvG (int& nBlock, double time, bool append)
 {
-  if (!this->SIMElasticity<Dim>::writeGlvG(nBlock,inpFile))
+  if (!this->SIMElasticity<Dim>::writeGlvG(nBlock,time,append))
     return false;
 
   return this->writeGlvBodies(this->getVTF(),nBlock);

--- a/FiniteDeformation/SIMFiniteDefEl.h
+++ b/FiniteDeformation/SIMFiniteDefEl.h
@@ -86,10 +86,11 @@ public:
 
   //! \brief Writes current model geometry to the VTF-file.
   //! \param nBlock Running result block counter
-  //! \param[in] inpFile File name used to construct the VTF-file name from
+  //! \param[in] time The time from which this (new) geometry applies
+  //! \param[in] append If \e true, append new blocks to existing ones, if any
   //!
   //! \details This method is overridden to also write out the contact bodies.
-  virtual bool writeGlvG(int& nBlock, const char* inpFile, bool = true);
+  virtual bool writeGlvG(int& nBlock, double time, bool append);
   //! \brief Writes contact body movements to the VTF-file.
   //! \param nBlock Running result block counter
   //! \param[in] iStep Load/time step identifier

--- a/Linear/DynamicDriver.C
+++ b/Linear/DynamicDriver.C
@@ -43,8 +43,8 @@ int dynamicSim (char* infile, SIMoutput* model, bool fixDup,
   if (!model->preprocess({},fixDup))
     return 2;
 
-  // Save FE model to VTF file for visualization
-  if (model->opt.format >= 0 && !simulator.saveModel(infile))
+  // Open VTF file for visualization
+  if (!model->openGlv(infile))
     return 3;
 
   // Define the initial configuration and initialize the solution vectors

--- a/Linear/SIMmcStatic.C
+++ b/Linear/SIMmcStatic.C
@@ -73,12 +73,12 @@ int SIMmcStatic::solveStatic (const char* inpfile,
     return 0; // No VTF output
 
   // Helper class for cleaning the VTF objects on termination
-  class clearVTF
+  class ClearVTF
   {
     std::vector<SIMoutput*>& ourSims;
   public:
-    clearVTF(std::vector<SIMoutput*>& sims) : ourSims(sims) {}
-    ~clearVTF() { for (SIMoutput* sim : ourSims) sim->setVTF(nullptr); }
+    ClearVTF(std::vector<SIMoutput*>& sims) : ourSims(sims) {}
+    ~ClearVTF() { for (SIMoutput* sim : ourSims) sim->setVTF(nullptr); }
   } vtfCleaner(mySims);
 
   // Write VTF-file with model geometry
@@ -91,7 +91,7 @@ int SIMmcStatic::solveStatic (const char* inpfile,
   {
     startBlk[i] = geoBlk;
     mySims[i]->setVTF(mySims.front()->getVTF());
-    if (!mySims[i]->writeGlvG(geoBlk,nullptr,true))
+    if (!mySims[i]->writeGlvG(geoBlk,0.0,true))
       return 12;
   }
 

--- a/Linear/SIMmcStatic.C
+++ b/Linear/SIMmcStatic.C
@@ -72,25 +72,27 @@ int SIMmcStatic::solveStatic (const char* inpfile,
   if (opt.format < 0)
     return 0; // No VTF output
 
-  // Lambda function for cleaning the VTF objects on termination.
-  auto&& terminate = [this](int status)
+  // Helper class for cleaning the VTF objects on termination
+  class clearVTF
   {
-    for (SIMoutput* sim : mySims)
-      sim->setVTF(nullptr);
-    return status;
-  };
+    std::vector<SIMoutput*>& ourSims;
+  public:
+    clearVTF(std::vector<SIMoutput*>& sims) : ourSims(sims) {}
+    ~clearVTF() { for (SIMoutput* sim : ourSims) sim->setVTF(nullptr); }
+  } vtfCleaner(mySims);
 
   // Write VTF-file with model geometry
   int geoBlk = 0, nBlock = 0;
   std::vector<int> startBlk(nSim,0);
   if (!mySims.front()->writeGlvG(geoBlk,inpfile))
-    return terminate(12);
-  else for (i = 1; i < nSim; i++)
+    return 12;
+
+  for (i = 1; i < nSim; i++)
   {
     startBlk[i] = geoBlk;
     mySims[i]->setVTF(mySims.front()->getVTF());
-    if (!mySims[i]->writeGlvG(geoBlk,nullptr,false))
-      return terminate(12);
+    if (!mySims[i]->writeGlvG(geoBlk,nullptr,true))
+      return 12;
   }
 
   // Write solution fields to VTF-file
@@ -99,11 +101,12 @@ int SIMmcStatic::solveStatic (const char* inpfile,
     mySims[i]->setMode(SIM::RECOVERY);
     mySims[i]->setStartGeo(startBlk[i]);
     if (!mySims[i]->writeGlvS(displ,1,nBlock))
-      return terminate(16);
+      return 16;
   }
 
   mySims.front()->writeGlvStep(1,0.0,-1);
   mySims.front()->closeGlv();
 
-  return terminate(0);
+  return 0;
+
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ mechanics problems, built using the [IFEM](https://github.com/OPM/IFEM) library.
 ### Getting the code
 
 This is done by first navigating to a folder `<App root>` in which you want
-the the applications and typing
+the applications and typing
 
     git clone https://github.com/OPM/IFEM-Elasticity
 

--- a/main_NonLinEl.C
+++ b/main_NonLinEl.C
@@ -48,19 +48,28 @@ int runSimulator (Simulator& simulator, SIMoutput* model, char* infile,
 {
   utl::profiler->start("Model input");
 
-  std::ostream* oss = nullptr;
-
-  // Lambda function cleaning heap-allocated objects before exiting.
-  auto&& exitSim = [oss,model](int status)
+  // Helper class cleaning the heap-allocated objects before exiting
+  class HeapObjects
   {
-    delete oss;
-    delete model;
-    return status;
-  };
+    SIMbase* ourSim;
+  public:
+    DataExporter* writer = nullptr;
+    HDF5Restart* restart = nullptr;
+    std::ostream* os = nullptr;
+
+    HeapObjects(SIMbase* sim) : ourSim(sim) {}
+    ~HeapObjects()
+    {
+      delete writer;
+      delete restart;
+      delete os;
+      delete ourSim;
+    }
+  } output(model);
 
   // Read in solver and model definitions
   if (!simulator.read(infile))
-    return exitSim(1);
+    return 1;
 
   // Let the stop time specified on command-line override input file setting
   if (stopTime > 0.0)
@@ -73,18 +82,11 @@ int runSimulator (Simulator& simulator, SIMoutput* model, char* infile,
 
   // Preprocess the model and establish data structures for the algebraic system
   if (!model->preprocess(ignoredPatches,fixDup))
-    return exitSim(2);
+    return 2;
 
-  if (model->opt.format >= 0)
-  {
-    // Save FE model to VTF file for visualization
-    if (model->getNoSpaceDim() < 3)
-      model->opt.nViz[2] = 1;
-    if (!simulator.saveModel(infile))
-      return exitSim(4);
-    else if (stopTime < 0.0 && !model->writeGlvStep(1))
-      return exitSim(4);
-  }
+  // Open VTF file for visualization
+  if (!model->openGlv(infile))
+    return 4;
 
   if (dtDump < 0.0)
   {
@@ -98,13 +100,14 @@ int runSimulator (Simulator& simulator, SIMoutput* model, char* infile,
     if (stopTime >= 0.0)
     {
       strcat(strtok(infile,"."),".sol");
-      oss = new std::ofstream(infile);
-      *oss <<"#NPoints="<< model->getNoNodes() <<"\n";
+      output.os = new std::ofstream(infile);
+      *output.os <<"#NPoints="<< model->getNoNodes() <<"\n";
     }
   }
 
-  if (stopTime < 0.0)
-    return exitSim(0); // model check
+  if (stopTime < 0.0) // model check
+    // Save FE model to VTF file for visualization
+    return simulator.saveModel() && model->writeGlvStep(1) ? 0 : 4;
 
   size_t numPatch = 1;
   const Elasticity* lelp;
@@ -135,18 +138,17 @@ int runSimulator (Simulator& simulator, SIMoutput* model, char* infile,
 
   // Initialize the linear equation solver
   if (!simulator.initEqSystem(!dynSim, dynSim ? 0 : model->getNoFields()))
-    return exitSim(3);
+    return 3;
 
   // Load solution state from serialized data in case of restart
   if (!simulator.checkForRestart())
-    return exitSim(5);
+    return 5;
 
   // Open HDF5 result database
-  DataExporter* writer = nullptr;
   if (model->opt.dumpHDF5(infile))
   {
-    const std::string& fileName = model->opt.hdf5;
-    IFEM::cout <<"\nWriting HDF5 file "<< fileName <<".hdf5"<< std::endl;
+    const std::string& fName = model->opt.hdf5;
+    IFEM::cout <<"\nWriting HDF5 file "<< fName <<".hdf5"<< std::endl;
 
     // Include secondary results only if no projection has been requested.
     // The secondary results will be projected anyway, but without the
@@ -161,29 +163,28 @@ int runSimulator (Simulator& simulator, SIMoutput* model, char* infile,
     if (model->hasElementActivator())
       results |= DataExporter::ELEMENT_MASK;
 
-    writer = new DataExporter(true,model->opt.saveInc);
-    writer->registerWriter(new HDF5Writer(fileName,model->getProcessAdm()));
-    writer->registerField("u","solution",DataExporter::SIM,results);
-    writer->setFieldValue("u",model,&simulator.getSolution(),
-                          nullptr,simulator.getNorms());
+    output.writer = new DataExporter(true,model->opt.saveInc);
+    output.writer->registerWriter(new HDF5Writer(fName,model->getProcessAdm()));
+    output.writer->registerField("u","solution",DataExporter::SIM,results);
+    output.writer->setFieldValue("u",model,&simulator.getSolution(),
+                                 nullptr,simulator.getNorms());
     if (dynSim)
     {
-      writer->registerField("v","velocity",DataExporter::SIM,
-                            -DataExporter::PRIMARY);
-      writer->setFieldValue("v",model,&dynSim->getVelocity());
-      writer->registerField("a","acceleration",DataExporter::SIM,
-                            -DataExporter::PRIMARY);
-      writer->setFieldValue("a",model,&dynSim->getAcceleration());
+      output.writer->registerField("v","velocity",DataExporter::SIM,
+                                   -DataExporter::PRIMARY);
+      output.writer->setFieldValue("v",model,&dynSim->getVelocity());
+      output.writer->registerField("a","acceleration",DataExporter::SIM,
+                                   -DataExporter::PRIMARY);
+      output.writer->setFieldValue("a",model,&dynSim->getAcceleration());
     }
     if (projectType)
     {
-      writer->registerField("sigma","projected",DataExporter::SIM,
-                            DataExporter::SECONDARY,projectType);
-      writer->setFieldValue("sigma",model,simulator.getProjection());
+      output.writer->registerField("sigma","projected",DataExporter::SIM,
+                                   DataExporter::SECONDARY,projectType);
+      output.writer->setFieldValue("sigma",model,simulator.getProjection());
     }
   }
 
-  HDF5Restart* restart = nullptr;
   if (model->opt.restartInc > 0)
   {
     std::string hdf5file(infile);
@@ -195,8 +196,8 @@ int runSimulator (Simulator& simulator, SIMoutput* model, char* infile,
     for (int i = 1; std::filesystem::exists(hdf5file + ".hdf5"); i++)
       hdf5file = hdf5file.substr(0,idot) + std::to_string(i);
     IFEM::cout <<"\nWriting HDF5 file "<< hdf5file <<".hdf5"<< std::endl;
-    restart = new HDF5Restart(hdf5file,model->getProcessAdm(),
-                              model->opt.restartInc);
+    output.restart = new HDF5Restart(hdf5file,model->getProcessAdm(),
+                                     model->opt.restartInc);
   }
 
   if (projectType)
@@ -204,14 +205,10 @@ int runSimulator (Simulator& simulator, SIMoutput* model, char* infile,
                <<"\nsmoothed secondary solution fields."<< std::endl;
 
   // Now invoke the main solution driver
-  utl::LogStream log(oss);
-  int status = simulator.solveProblem(writer, restart, oss ? &log : nullptr,
-                                      printMax, std::abs(dtDump),
-                                      zero_tol, outPrec);
-
-  delete writer;
-  delete restart;
-  return exitSim(status);
+  utl::LogStream log(output.os);
+  return simulator.solveProblem(output.writer, output.restart,
+                                output.os ? &log : nullptr,
+                                printMax, std::abs(dtDump), zero_tol, outPrec);
 }
 
 
@@ -288,18 +285,18 @@ int main (int argc, char** argv)
     {
       dtDump = atof(argv[++i]);
       if (++i < argc && !strcmp(argv[i],"raw"))
-	dtDump *= -1;
+        dtDump *= -1;
       else
-	--i;
+        --i;
     }
 #ifndef USE_OPENMP
     else if (!strcmp(argv[i],"-dbgElm"))
       while (i < argc-1 && isdigit(argv[i+1][0]))
-	utl::parseIntegers(dbgElms,argv[++i]);
+        utl::parseIntegers(dbgElms,argv[++i]);
 #endif
     else if (!strcmp(argv[i],"-ignore"))
       while (i < argc-1 && isdigit(argv[i+1][0]))
-	utl::parseIntegers(ignoredPatches,argv[++i]);
+        utl::parseIntegers(ignoredPatches,argv[++i]);
     else if (!strcmp(argv[i],"-vox") && i < argc-1)
       VTF::vecOffset[0] = atof(argv[++i]);
     else if (!strcmp(argv[i],"-voy") && i < argc-1)

--- a/main_ShellEl.C
+++ b/main_ShellEl.C
@@ -27,7 +27,7 @@
 */
 
 template<class Simulator>
-int runSimulator (Simulator& simulator, SIMbase& model, char* infile,
+int runSimulator (Simulator& simulator, SIMoutput& model, char* infile,
                   double stopTime, double zero_tol, double outPrec)
 {
   utl::profiler->start("Model input");
@@ -47,16 +47,13 @@ int runSimulator (Simulator& simulator, SIMbase& model, char* infile,
   if (!model.preprocess())
     return 2;
 
-  if (model.opt.format >= 0)
-  {
-    // Save FE model to VTF file for visualization
-    model.opt.nViz[2] = 1;
-    if (!simulator.saveModel(infile))
-      return 3;
-  }
+  // Open VTF file for visualization
+  if (!model.openGlv(infile))
+    return 3;
 
-  if (stopTime < 0.0)
-    return 0; // Data check only, no simulation
+  if (stopTime < 0.0) // Data check only, no simulation
+    // Save FE model to VTF file for visualization
+    return simulator.saveModel() && model.writeGlvStep(1) ? 0 : 3;
 
   // Initialize the solution vectors
   simulator.initSol();


### PR DESCRIPTION
To account for models with evolving geometry (element activation and adaptive grids).

Requires OPM/IFEM#880.