### PR TITLE
Changed: Swap to right-hand-system parametrization to avoid negative norms

### DIFF
--- a/Test/Linear/AnnulusWithTemp2D.reg
+++ b/Test/Linear/AnnulusWithTemp2D.reg
@@ -1,13 +1,18 @@
-AnnulusWithTemp2D.xinp -2Dpstrain
+AnnulusWithTemp2D.xinp -2Dpstrain -checkRHS
 
 Input file: AnnulusWithTemp2D.xinp
 Equation solver: 2
 Number of Gauss points: 4
+Basis function values are precalculated but not cached
+Evaluation time for property functions: 1
+Check that each patch has a right-hand coordinate system
+Solution component output zero tolerance: 1e-06
 Parsing input file AnnulusWithTemp2D.xinp
 Parsing <geometry>
   Parsing <patchfile>
 	Reading data file quartulus.g2
 	Reading patch 1
+	Swapped.
   Parsing <raiseorder>
   Parsing <refine>
   Parsing <topologysets>
@@ -24,13 +29,16 @@ Parsing <elasticity>
 	Dirichlet code 1: (fixed)
   Parsing <dirichlet>
 	Dirichlet code 2: (fixed)
+  Parsing <isotropic>
 	Material code 0: 2e+11 0.3 7850 1.2e-05
 	Initial temperature: 273
 	Temperature: r=sqrt(x\*x+y\*y); a=0.03; b=0.04; Ti=373.0; To=293.0; Ti+(To-Ti)\*log(r/a)/log(b/a)
-	Analytical solution: Pipe Ri=0.03 Ro=0.04 Ti=373 To=293
+  Parsing <anasol>
+	Analytical solution: Pipe Ri=0.03 Ro=0.04 Ti=373 To=293 Tref=273
 Parsing input file succeeded.
 Equation solver: 2
 Number of Gauss points: 4
+Basis function values are precalculated but not cached
 Problem definition:
 Elasticity: 2D, gravity = 0 0
 LinIsotropic: E = 2e+11, nu = 0.3, rho = 7850, alpha = 1.2e-05
@@ -45,6 +53,8 @@ Number of unknowns    648
 Number of quadrature points 4096
 Processing integrand associated with code 0
 Assembling interior matrix terms for P1
+Done.
+Sum external load : 2.67976e+06 2.67976e+06 0
 Solving the equation system ...
 	Condition number: 577535
  >>> Solution summary <<<
@@ -53,17 +63,24 @@ Max X-displacement : 2.69689e-05
 Max Y-displacement : 2.69689e-05
 Projecting secondary solution ...
 	Greville point projection
-Energy norm |u^h| = a(u^h,u^h)^0.5   : -3.02129
-Exact norm  |u|   = a(u,u)^0.5       : -3.02129
-Exact error a(e,e)^0.5, e=u-u^h      : -0.00144707
+Integrating solution norms (FE solution) ...
+Integrating solution norms (reference solution) ...
+Energy norm |u^h| = a(u^h,u^h)^0.5   : 3.02129
+Exact norm  |u|   = a(u,u)^0.5       : 3.02129
+Exact error a(e,e)^0.5, e=u-u^h      : 0.00144707
 Exact relative error (%) : 0.0478958
 >>> Error estimates based on Greville point projection <<<
-Energy norm |u^r| = a(u^r,u^r)^0.5   : -3.02117
-Error norm a(e,e)^0.5, e=u^r-u^h     : -0.00217803
+Energy norm |u^r| = a(u^r,u^r)^0.5   : 3.02117
+Error norm a(e,e)^0.5, e=u^r-u^h     : 0.00217803
  relative error (% of |u|)   : 0.0720893
-Exact error a(e,e)^0.5, e=u-u^r      : -0.00170025
+Exact error a(e,e)^0.5, e=u-u^r      : 0.00170025
  relative error (% of |u|)   : 0.0562756
 Effectivity index             : 1.50513
-L2-norm |s^r| = (s^r,s^r)^0.5        : -1.32478e+06
-L2-error (e,e)^0.5, e=s^r-s^h        : -1208.39
+Energy norm |u^rr| = a(u^rr,u^rr)^0.5: 3.02128
+Error norm a(e,e)^0.5, e=u^rr-u^h    : 0.00144704
+ relative error (% of |u|)   : 0.0478947
+Exact error a(e,e)^0.5, e=u-u^rr     : 1.45184e-05
+ relative error (% of |u|)   : 0.000480539
+L2-norm |s^r| = (s^r,s^r)^0.5        : 1.32478e+06
+L2-error (e,e)^0.5, e=s^r-s^h        : 1208.39
  relative error (% of |s^r|) : 0.091214

--- a/Test/Linear/SPR/AnnulusWithTemp2D.reg
+++ b/Test/Linear/SPR/AnnulusWithTemp2D.reg
@@ -1,13 +1,18 @@
-../AnnulusWithTemp2D.xinp -2Dpstrain -spr
+../AnnulusWithTemp2D.xinp -2Dpstrain -checkRHS -spr
 
 Input file: AnnulusWithTemp2D.xinp
 Equation solver: 1
 Number of Gauss points: 4
+Basis function values are precalculated but not cached
+Evaluation time for property functions: 1
+Check that each patch has a right-hand coordinate system
+Solution component output zero tolerance: 1e-06
 Parsing input file AnnulusWithTemp2D.xinp
 Parsing <geometry>
   Parsing <patchfile>
 	Reading data file quartulus.g2
 	Reading patch 1
+	Swapped.
   Parsing <raiseorder>
   Parsing <refine>
   Parsing <topologysets>
@@ -24,13 +29,16 @@ Parsing <elasticity>
 	Dirichlet code 1: (fixed)
   Parsing <dirichlet>
 	Dirichlet code 2: (fixed)
+  Parsing <isotropic>
 	Material code 0: 2e+11 0.3 7850 1.2e-05
 	Initial temperature: 273
 	Temperature: r=sqrt(x\*x+y\*y); a=0.03; b=0.04; Ti=373.0; To=293.0; Ti+(To-Ti)\*log(r/a)/log(b/a)
-	Analytical solution: Pipe Ri=0.03 Ro=0.04 Ti=373 To=293
+  Parsing <anasol>
+	Analytical solution: Pipe Ri=0.03 Ro=0.04 Ti=373 To=293 Tref=273
 Parsing input file succeeded.
 Equation solver: 1
 Number of Gauss points: 4
+Basis function values are precalculated but not cached
 Problem definition:
 Elasticity: 2D, gravity = 0 0
 LinIsotropic: E = 2e+11, nu = 0.3, rho = 7850, alpha = 1.2e-05
@@ -45,6 +53,8 @@ Number of unknowns    648
 Number of quadrature points 4096
 Processing integrand associated with code 0
 Assembling interior matrix terms for P1
+Done.
+Sum external load : 2.67976e+06 2.67976e+06 0
 Solving the equation system ...
  >>> Solution summary <<<
 L2-norm            : 1.74959e-05
@@ -52,17 +62,24 @@ Max X-displacement : 2.69689e-05
 Max Y-displacement : 2.69689e-05
 Projecting secondary solution ...
 	Greville point projection
-Energy norm |u^h| = a(u^h,u^h)^0.5   : -3.02129
-Exact norm  |u|   = a(u,u)^0.5       : -3.02129
-Exact error a(e,e)^0.5, e=u-u^h      : -0.00144707
+Integrating solution norms (FE solution) ...
+Integrating solution norms (reference solution) ...
+Energy norm |u^h| = a(u^h,u^h)^0.5   : 3.02129
+Exact norm  |u|   = a(u,u)^0.5       : 3.02129
+Exact error a(e,e)^0.5, e=u-u^h      : 0.00144707
 Exact relative error (%) : 0.0478958
 >>> Error estimates based on Greville point projection <<<
-Energy norm |u^r| = a(u^r,u^r)^0.5   : -3.02117
-Error norm a(e,e)^0.5, e=u^r-u^h     : -0.00217803
+Energy norm |u^r| = a(u^r,u^r)^0.5   : 3.02117
+Error norm a(e,e)^0.5, e=u^r-u^h     : 0.00217803
  relative error (% of |u|)   : 0.0720893
-Exact error a(e,e)^0.5, e=u-u^r      : -0.00170025
+Exact error a(e,e)^0.5, e=u-u^r      : 0.00170025
  relative error (% of |u|)   : 0.0562756
 Effectivity index             : 1.50513
-L2-norm |s^r| = (s^r,s^r)^0.5        : -1.32478e+06
-L2-error (e,e)^0.5, e=s^r-s^h        : -1208.39
+Energy norm |u^rr| = a(u^rr,u^rr)^0.5: 3.02128
+Error norm a(e,e)^0.5, e=u^rr-u^h    : 0.00144704
+ relative error (% of |u|)   : 0.0478947
+Exact error a(e,e)^0.5, e=u-u^rr     : 1.45184e-05
+ relative error (% of |u|)   : 0.000480539
+L2-norm |s^r| = (s^r,s^r)^0.5        : 1.32478e+06
+L2-error (e,e)^0.5, e=s^r-s^h        : 1208.39
  relative error (% of |s^r|) : 0.091214


### PR DESCRIPTION
And such that we can trace negative Jacobian determinants as errors in large deformation problems